### PR TITLE
fix: formating error message before using

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
     "moment": "^2.27.0",
     "nan": "^2.14.1",
     "node-pre-gyp": "^0.15.0",
-    "uuid": "^8.1.0",
-    "yargs": "^15.3.1"
+    "uuid": "^8.2.0",
+    "yargs": "^15.4.1"
   },
   "devDependencies": {
     "@istanbuljs/schema": "^0.1.2",

--- a/src/library/utils.h
+++ b/src/library/utils.h
@@ -23,9 +23,15 @@ T GetJsonValue(json data, string key, XpfError &err) {
   try {
     result = data[key].get<T>();
   } catch (json::exception &e) {
+    // format error message
+    // ref: https://en.cppreference.com/w/cpp/error/exception/what
+    char error_message[256];
+    snprintf(error_message, sizeof(error_message), "%s", e.what());
+
+    // log error message
     Error("type_value", "%s <%s> type error: %s", data.dump().c_str(),
-          key.c_str(), e.what());
-    err = XpfError::Failure("<%s> type error: %s", key.c_str(), e.what());
+          key.c_str(), error_message);
+    err = XpfError::Failure("<%s> type error: %s", key.c_str(), error_message);
   }
   return result;
 }


### PR DESCRIPTION
 ref: https://en.cppreference.com/w/cpp/error/exception/what