### PR TITLE
fix: compile warning in vs2019 at windows

### DIFF
--- a/src/logbypass/gc.h
+++ b/src/logbypass/gc.h
@@ -4,7 +4,7 @@
 #include "nan.h"
 
 namespace xprofiler {
-typedef struct {
+typedef struct GcStatistics {
  public:
   // total gc times
   unsigned int total_gc_times = 0;

--- a/src/logbypass/heap.h
+++ b/src/logbypass/heap.h
@@ -28,7 +28,7 @@ using v8::HeapStatistics;
       heap_space_statistics->name##_space_committed
 
 // heap statistics struct
-typedef struct {
+typedef struct XprofilerHeapStatistics {
  public:
   HeapStatistics *handle() { return &heap_statistics_; }
   size_t total_heap_size() { return heap_statistics_.total_heap_size(); }
@@ -59,7 +59,7 @@ typedef struct {
 } heap_statistics_t;
 
 // heap space statistics struct
-typedef struct {
+typedef struct XprofilerHeapSpaceStatistics {
   INIT_SPACE_INFO(new)
   INIT_SPACE_INFO(old)
   INIT_SPACE_INFO(code)

--- a/src/logbypass/libuv.h
+++ b/src/logbypass/libuv.h
@@ -13,7 +13,7 @@ namespace xprofiler {
   active_##name##_handles = HANDLE_DEFAULT_VALUE; \
   active_and_ref_##name##_handles = HANDLE_DEFAULT_VALUE;
 
-typedef struct {
+typedef struct UvHandleStatistics {
   INIT_UV_HANDLE(file)
   INIT_UV_HANDLE(tcp)
   INIT_UV_HANDLE(udp)


### PR DESCRIPTION
Ref: https://docs.microsoft.com/zh-cn/cpp/error-messages/compiler-warnings/c5208?view=vs-2019