### PR TITLE
fix: ignore ENOENT error when cleaning logdir

### DIFF
--- a/lib/clean.js
+++ b/lib/clean.js
@@ -29,5 +29,14 @@ module.exports = function clean(logdir) {
 
   // clean these files
   needClean = needClean.concat(needCleanSocks);
-  needClean.forEach(filename => fs.unlinkSync(path.join(logdir, filename)));
+  needClean.forEach(filename => {
+    try {
+      fs.unlinkSync(path.join(logdir, filename));
+    } catch (err) {
+      // ignore ENOENT error caused by race condition
+      if (err.code !== 'ENOENT') {
+        throw err;
+      }
+    }
+  });
 };

--- a/lib/clean.js
+++ b/lib/clean.js
@@ -32,11 +32,8 @@ module.exports = function clean(logdir) {
   needClean.forEach(filename => {
     try {
       fs.unlinkSync(path.join(logdir, filename));
-    } catch (err) {
-      // ignore ENOENT error caused by race condition
-      if (err.code !== 'ENOENT') {
-        throw err;
-      }
+    } catch (err) /* istanbul ignore next */ {
+      console.error(err);
     }
   });
 };


### PR DESCRIPTION
There is a race condition when multi processes are cleaning logdir.

```
Error: ENOENT: no such file or directory, unlink '/Users/claude/demo/logs/xprofiler-uds-path-17977.sock'
    at Object.unlinkSync (fs.js:1136:3)
    at /Users/claude/demo/node_modules/xprofiler/lib/clean.js:35:10
    at Array.forEach (<anonymous>)
    at clean (/Users/claude/demo/node_modules/xprofiler/lib/clean.js:33:13)
    at Function.start (/Users/claude/demo/node_modules/xprofiler/xprofiler.js:65:3)
    at Object.<anonymous> (/Users/claude/demo/index.js:10:11)
    at Module._compile (internal/modules/cjs/loader.js:1137:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1157:10)
    at Module.load (internal/modules/cjs/loader.js:985:32)
    at Function.Module._load (internal/modules/cjs/loader.js:878:14)
```
