### PR TITLE
release v1.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xprofiler",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "node.js addon to output runtime logs",
   "bin": {
     "xprofctl": "bin/xprofctl"

--- a/scripts/7u.js
+++ b/scripts/7u.js
@@ -7,7 +7,7 @@ const nodeVersions = [
   'node-v13.14.0',
   'node-v14.6.0',
   'node-v15.1.0',
-  'node-v16.0.0',
+  'node-v16.1.0',
 ];
 
 build(nodeVersions);

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -5,13 +5,13 @@ const build = require('./build');
 const nodeVersions = [
   'node-v8.17.0',
   'node-v9.11.2',
-  'node-v10.22.0',
+  'node-v10.24.1',
   'node-v11.15.0',
-  'node-v12.18.3',
+  'node-v12.19.1',
   'node-v13.14.0',
-  'node-v14.6.0',
-  'node-v15.1.0',
-  'node-v16.0.0',
+  'node-v14.16.1',
+  'node-v15.14.0',
+  'node-v16.1.0',
 ];
 
 build(nodeVersions);

--- a/scripts/copy.js
+++ b/scripts/copy.js
@@ -6,7 +6,7 @@ const { promisify } = require('util');
 const exists = promisify(fs.exists);
 const mkdir = promisify(fs.mkdir);
 const copyFile = promisify(fs.copyFile);
-const versioning = require('node-pre-gyp/lib/util/versioning.js');
+const versioning = require('@mapbox/node-pre-gyp/lib/util/versioning.js');
 const { staged_tarball: packagePath } = versioning.evaluate(require('../package.json'));
 
 async function copy() {


### PR DESCRIPTION
Notable Changes:
* Support `node-v16.x`

Commits:
* [c446ebb] chore: using git actions instead of travis ( linux / darwin )
* [b7e23e1] fix: process cpu usage
* [7bea901] fix: ignore codecov.io reporting failure
* [30bcdd1] feat: support node-v16.x


PR-URL: https://github.com/X-Profiler/xprofiler/pull/98
Committed-BY: [hyj1991](https://github.com/hyj1991)