### PR TITLE
feat: enclose config slots in per process store

### DIFF
--- a/bin/xprofctl
+++ b/bin/xprofctl
@@ -37,19 +37,15 @@ const args = yargs
   .command('set_config', '设置 xprofiler 配置',
     yargs => yargs
       .group(['enable_log_uv_handles', 'disable_log_uv_handles', 'log_level',
-        'log_type', 'enable_fatal_error_hook', 'disable_fatal_error_hook'], '配置项:')
+        'log_type'], '配置项:')
       .describe('enable_log_uv_handles', '开启 libuv 句柄详情采集')
       .describe('disable_log_uv_handles', '关闭 libuv 句柄详情采集')
       .describe('log_level', '日志级别: info, error, debug')
       .describe('log_type', '日志输出未知: 文件, 控制台')
-      .describe('enable_fatal_error_hook', '开启 Fatal Error 钩子')
-      .describe('disable_fatal_error_hook', '关闭 Fatal Error 钩子')
       .boolean('enable_log_uv_handles')
       .boolean('disable_log_uv_handles')
       .choices('log_level', [0, 1, 2])
       .choices('log_type', [0, 1])
-      .boolean('enable_fatal_error_hook')
-      .boolean('disable_fatal_error_hook')
       .hide('v')
       .hide('h'))
   // pid

--- a/bin/xprofctl.json
+++ b/bin/xprofctl.json
@@ -19,9 +19,7 @@
       "disable_log_uv_handles": "boolean",
       "enable_log_uv_handles": "boolean",
       "log_level": "number",
-      "log_type": "number",
-      "enable_fatal_error_hook": "boolean",
-      "disable_fatal_error_hook": "boolean"
+      "log_type": "number"
     }
   }
 ]

--- a/binding.gyp
+++ b/binding.gyp
@@ -39,8 +39,12 @@
                 "src/commands/report/system_statistics.cc",
                 "src/hooks/set_hooks.cc",
                 "src/hooks/fatal_error.cc",
+                "src/util.cc",
             ],
-            "include_dirs": ['<!(node -e "require(\'nan\')")'],
+            "include_dirs": [
+                'src',
+                '<!(node -e "require(\'nan\')")'
+            ],
             "cflags_cc!": ["-fno-exceptions"],
             "conditions": [
                 ["OS == 'linux'", {

--- a/src/commands/dump.cc
+++ b/src/commands/dump.cc
@@ -1,8 +1,8 @@
 #include "dump.h"
 
-#include "../configure.h"
 #include "../logger.h"
 #include "../platform/platform.h"
+#include "configure-inl.h"
 #include "cpuprofiler/cpu_profiler.h"
 #include "gcprofiler/gc_profiler.h"
 #include "heapdump/heap_profiler.h"

--- a/src/commands/simple/config.cc
+++ b/src/commands/simple/config.cc
@@ -1,6 +1,6 @@
-#include "../../configure.h"
 #include "../../library/json.hpp"
 #include "../../library/utils.h"
+#include "configure-inl.h"
 
 namespace xprofiler {
 using nlohmann::json;
@@ -43,7 +43,6 @@ COMMAND_CALLBACK(SetXprofilerConfig) {
   HANDLE_CONFIG_SETTING(LOG_LEVEL, log_level, LogLevel)
   HANDLE_CONFIG_SETTING(LOG_TYPE, log_type, LogType)
   HANDLE_CONFIG_SETTING(bool, enable_log_uv_handles, EnableLogUvHandles)
-  HANDLE_CONFIG_SETTING(bool, enable_fatal_error_hook, EnableFatalErrorHook)
 
   if (!setted)
     error(format("not support setting config %s", options.dump().c_str()));

--- a/src/configure-inl.h
+++ b/src/configure-inl.h
@@ -1,0 +1,47 @@
+#ifndef XPROFILER_SRC_CONFIGURE_INL_H
+#define XPROFILER_SRC_CONFIGURE_INL_H
+
+#include "configure.h"
+
+namespace xprofiler {
+std::string GetLogDir() { return per_process::config_store.log_dir; }
+
+uint32_t GetLogInterval() { return per_process::config_store.log_interval; }
+
+LOG_LEVEL GetLogLevel() { return per_process::config_store.log_level; }
+
+LOG_TYPE GetLogType() { return per_process::config_store.log_type; }
+
+bool GetFormatAsAlinode() {
+  return per_process::config_store.log_format_alinode;
+}
+
+bool GetEnableLogUvHandles() {
+  return per_process::config_store.enable_log_uv_handles;
+}
+
+bool GetEnableFatalErrorHook() {
+  return per_process::config_store.enable_fatal_error_hook;
+}
+
+bool GetPatchHttp() { return per_process::config_store.patch_http; }
+
+uint32_t GetPatchHttpTimeout() {
+  return per_process::config_store.patch_http_timeout;
+}
+
+bool GetCheckThrow() { return per_process::config_store.check_throw; }
+
+void SetLogLevel(LOG_LEVEL value) {
+  per_process::config_store.log_level = value;
+}
+
+void SetLogType(LOG_TYPE value) { per_process::config_store.log_type = value; }
+
+void SetEnableLogUvHandles(bool value) {
+  per_process::config_store.enable_log_uv_handles = value;
+}
+
+}  // namespace xprofiler
+
+#endif /* XPROFILER_SRC_CONFIGURE_INL_H */

--- a/src/configure.h
+++ b/src/configure.h
@@ -1,74 +1,50 @@
-#ifndef _SRC_CONFIGURE_H
-#define _SRC_CONFIGURE_H
+#ifndef XPROFILER_SRC_CONFIGURE_H
+#define XPROFILER_SRC_CONFIGURE_H
 
 #include "library/common.h"
 #include "library/error.h"
 #include "nan.h"
 
 namespace xprofiler {
-using Nan::FunctionCallbackInfo;
-using std::string;
-using v8::Value;
 
-#define DECLARE_GETTER_FUNCTION(func_name, type) type Get##func_name()
+inline string GetLogDir();
+inline uint32_t GetLogInterval();
+inline LOG_LEVEL GetLogLevel();
+inline LOG_TYPE GetLogType();
+inline bool GetFormatAsAlinode();
+inline bool GetEnableLogUvHandles();
+inline bool GetEnableFatalErrorHook();
+inline bool GetPatchHttp();
+inline uint32_t GetPatchHttpTimeout();
+inline bool GetCheckThrow();
 
-#define DECLARE_SETTER_FUNCTION(func_name, type) void Set##func_name(type value)
-
-#define DECLARE_GET_SET_FUNCTION(func_name, type) \
-  DECLARE_GETTER_FUNCTION(func_name, type);       \
-  DECLARE_SETTER_FUNCTION(func_name, type);
-
-#define DEFINE_GET_SET_FUNCTION(func_name, type, vari)      \
-  DECLARE_GETTER_FUNCTION(func_name, type) { return vari; } \
-  DECLARE_SETTER_FUNCTION(func_name, type) { vari = value; }
-
-#define LOCAL_VALUE(key)     \
-  Local<Value> key##_value = \
-      Get(config, New<String>(#key).ToLocalChecked()).ToLocalChecked();
-
-#define COVERT_STRING(key)                                                 \
-  LOCAL_VALUE(key)                                                         \
-  if (key##_value->IsString()) {                                           \
-    Local<String> key##_string = To<String>(key##_value).ToLocalChecked(); \
-    Utf8String key##_utf8string(key##_string);                             \
-    key = *key##_utf8string;                                               \
-  }
-
-#define CONVERT_UINT32(key) \
-  LOCAL_VALUE(key)          \
-  if (key##_value->IsUint32()) key = To<uint32_t>(key##_value).ToChecked();
-
-#define CONVERT_UINT32_WITH_TYPE(key, type) \
-  LOCAL_VALUE(key)                          \
-  if (key##_value->IsUint32())              \
-    key = static_cast<type>(To<uint32_t>(key##_value).ToChecked());
-
-#define CONVERT_BOOL(key) \
-  LOCAL_VALUE(key)        \
-  if (key##_value->IsBoolean()) key = To<bool>(key##_value).ToChecked();
-
-#define CONFIG_LOCAL_STRING(key, type)            \
-  Set(config, New<String>(#key).ToLocalChecked(), \
-      New<type>(key).ToLocalChecked());
-
-#define CONFIG_NATIVE_NUMBER(key, type) \
-  Set(config, New<String>(#key).ToLocalChecked(), New<type>(key));
-
-// declare getter / setter
-DECLARE_GET_SET_FUNCTION(LogDir, string)
-DECLARE_GET_SET_FUNCTION(LogInterval, uint32_t)
-DECLARE_GET_SET_FUNCTION(LogLevel, LOG_LEVEL)
-DECLARE_GET_SET_FUNCTION(LogType, LOG_TYPE)
-DECLARE_GET_SET_FUNCTION(FormatAsAlinode, bool)
-DECLARE_GET_SET_FUNCTION(EnableLogUvHandles, bool)
-DECLARE_GET_SET_FUNCTION(EnableFatalErrorHook, bool)
-DECLARE_GET_SET_FUNCTION(PatchHttp, bool)
-DECLARE_GET_SET_FUNCTION(PatchHttpTimeout, uint32_t)
-DECLARE_GET_SET_FUNCTION(CheckThrow, bool)
+inline void SetLogLevel(LOG_LEVEL value);
+inline void SetLogType(LOG_TYPE value);
+inline void SetEnableLogUvHandles(bool value);
 
 // javascript accessible
-void Configure(const FunctionCallbackInfo<Value> &info);
-void GetConfig(const FunctionCallbackInfo<Value> &info);
+void Configure(const Nan::FunctionCallbackInfo<v8::Value> &info);
+void GetConfig(const Nan::FunctionCallbackInfo<v8::Value> &info);
+
+class ConfigStore {
+  // TODO(legendecas): accessors.
+ public:
+  std::string log_dir = "/tmp";
+  uint32_t log_interval = 60;
+  LOG_LEVEL log_level = LOG_ERROR;
+  LOG_TYPE log_type = LOG_TO_FILE;
+  bool enable_log_uv_handles = true;
+  bool log_format_alinode = false;
+  bool enable_fatal_error_hook = true;
+  bool patch_http = true;
+  uint32_t patch_http_timeout = 30;
+  bool check_throw = true;
+};
+
+namespace per_process {
+extern ConfigStore config_store;
+}
+
 }  // namespace xprofiler
 
-#endif
+#endif /* XPROFILER_SRC_CONFIGURE_H */

--- a/src/hooks/fatal_error.cc
+++ b/src/hooks/fatal_error.cc
@@ -1,8 +1,8 @@
 #include "../commands/report/node_report.h"
-#include "../configure.h"
 #include "../library/utils.h"
 #include "../logger.h"
 #include "../platform/platform.h"
+#include "configure-inl.h"
 #include "nan.h"
 
 namespace xprofiler {

--- a/src/hooks/set_hooks.cc
+++ b/src/hooks/set_hooks.cc
@@ -1,6 +1,6 @@
 #include "set_hooks.h"
 
-#include "../configure.h"
+#include "configure-inl.h"
 #include "fatal_error.h"
 
 namespace xprofiler {

--- a/src/library/common.cc
+++ b/src/library/common.cc
@@ -20,9 +20,7 @@ using v8::Value;
 static time_t load_time;
 static string global_node_version_string = NODE_VERSION;
 
-void InitGlobalVariables() {
-  time(&load_time);
-}
+void InitGlobalVariables() { time(&load_time); }
 
 unsigned long GetUptime() {
   time_t current_time;

--- a/src/logbypass/libuv.cc
+++ b/src/logbypass/libuv.cc
@@ -1,7 +1,7 @@
 #include "libuv.h"
 
-#include "../configure.h"
 #include "../logger.h"
+#include "configure-inl.h"
 #include "uv.h"
 
 namespace xprofiler {

--- a/src/logbypass/log.cc
+++ b/src/logbypass/log.cc
@@ -1,6 +1,6 @@
-#include "../configure.h"
 #include "../library/utils.h"
 #include "../logger.h"
+#include "configure-inl.h"
 #include "cpu.h"
 #include "gc.h"
 #include "heap.h"

--- a/src/logger.cc
+++ b/src/logger.cc
@@ -8,7 +8,7 @@
 #include <time.h>
 #endif
 
-#include "configure.h"
+#include "configure-inl.h"
 #include "platform/platform.h"
 
 namespace xprofiler {

--- a/src/platform/unix/ipc.cc
+++ b/src/platform/unix/ipc.cc
@@ -4,8 +4,8 @@
 #include <sys/un.h>
 #include <unistd.h>
 
-#include "../../configure.h"
 #include "../../logger.h"
+#include "configure-inl.h"
 
 namespace xprofiler {
 using Nan::FunctionCallbackInfo;

--- a/src/platform/win/ipc_win.cc
+++ b/src/platform/win/ipc_win.cc
@@ -1,8 +1,8 @@
 #ifdef _WIN32
 #include <windows.h>
 
-#include "../../configure.h"
 #include "../../logger.h"
+#include "configure-inl.h"
 #include "uv.h"
 
 namespace xprofiler {

--- a/src/util-inl.h
+++ b/src/util-inl.h
@@ -1,0 +1,20 @@
+#ifndef XPROFILER_SRC_UTIL_INL_H
+#define XPROFILER_SRC_UTIL_INL_H
+
+#include <nan.h>
+
+#include "util.h"
+
+namespace xprofiler {
+
+inline v8::Local<v8::String> OneByteString(v8::Isolate* isolate,
+                                           const char* data, int length) {
+  // Nan get implicit isolate from Isolate::GetCurrent.
+  DCHECK_EQ(isolate, Isolate::GetCurrent());
+  return Nan::NewOneByteString(reinterpret_cast<const uint8_t*>(data), length)
+      .ToLocalChecked();
+}
+
+}  // namespace xprofiler
+
+#endif /* XPROFILER_SRC_UTIL_INL_H */

--- a/src/util.cc
+++ b/src/util.cc
@@ -1,0 +1,20 @@
+#include "util.h"
+
+#include <cstdio>
+#include <cstdlib>
+
+namespace xprofiler {
+[[noreturn]] void Abort() {
+  std::fflush(stderr);
+  std::abort();
+}
+
+[[noreturn]] void Assert(const AssertionInfo& info) {
+  fprintf(stderr, "xprofiler: %s:%s%s Assertion `%s' failed.\n", info.file_line,
+          info.function, *info.function ? ":" : "", info.message);
+  fflush(stderr);
+
+  Abort();
+}
+
+}  // namespace xprofiler

--- a/src/util.h
+++ b/src/util.h
@@ -1,0 +1,81 @@
+#ifndef XPROFILER_SRC_UTIL_H
+#define XPROFILER_SRC_UTIL_H
+
+#include <v8.h>
+
+namespace xprofiler {
+
+// The reason that Assert() takes a struct argument instead of individual
+// const char*s is to ease instruction cache pressure in calls from CHECK.
+struct AssertionInfo {
+  const char* file_line;  // filename:line
+  const char* message;
+  const char* function;
+};
+[[noreturn]] void Abort();
+[[noreturn]] void Assert(const AssertionInfo& info);
+
+#define ERROR_AND_ABORT(expr)                                                 \
+  do {                                                                        \
+    /* Make sure that this struct does not end up in inline code, but      */ \
+    /* rather in a read-only data section when modifying this code.        */ \
+    static const xprofiler::AssertionInfo args = {                            \
+        __FILE__ ":" STRINGIFY(__LINE__), #expr, PRETTY_FUNCTION_NAME};       \
+    xprofiler::Assert(args);                                                  \
+  } while (0)
+
+#define LIKELY(expr) __builtin_expect(!!(expr), 1)
+#define UNLIKELY(expr) __builtin_expect(!!(expr), 0)
+#define PRETTY_FUNCTION_NAME __PRETTY_FUNCTION__
+
+#define STRINGIFY_(x) #x
+#define STRINGIFY(x) STRINGIFY_(x)
+
+#define CHECK(expr)          \
+  do {                       \
+    if (UNLIKELY(!(expr))) { \
+      ERROR_AND_ABORT(expr); \
+    }                        \
+  } while (0)
+
+#define CHECK_EQ(a, b) CHECK((a) == (b))
+#define CHECK_GE(a, b) CHECK((a) >= (b))
+#define CHECK_GT(a, b) CHECK((a) > (b))
+#define CHECK_LE(a, b) CHECK((a) <= (b))
+#define CHECK_LT(a, b) CHECK((a) < (b))
+#define CHECK_NE(a, b) CHECK((a) != (b))
+#define CHECK_NULL(val) CHECK((val) == nullptr)
+#define CHECK_NOT_NULL(val) CHECK((val) != nullptr)
+#define CHECK_IMPLIES(a, b) CHECK(!(a) || (b))
+
+#ifdef DEBUG
+#define DCHECK(expr) CHECK(expr)
+#define DCHECK_EQ(a, b) CHECK((a) == (b))
+#define DCHECK_GE(a, b) CHECK((a) >= (b))
+#define DCHECK_GT(a, b) CHECK((a) > (b))
+#define DCHECK_LE(a, b) CHECK((a) <= (b))
+#define DCHECK_LT(a, b) CHECK((a) < (b))
+#define DCHECK_NE(a, b) CHECK((a) != (b))
+#define DCHECK_NULL(val) CHECK((val) == nullptr)
+#define DCHECK_NOT_NULL(val) CHECK((val) != nullptr)
+#define DCHECK_IMPLIES(a, b) CHECK(!(a) || (b))
+#else
+#define DCHECK(expr)
+#define DCHECK_EQ(a, b)
+#define DCHECK_GE(a, b)
+#define DCHECK_GT(a, b)
+#define DCHECK_LE(a, b)
+#define DCHECK_LT(a, b)
+#define DCHECK_NE(a, b)
+#define DCHECK_NULL(val)
+#define DCHECK_NOT_NULL(val)
+#define DCHECK_IMPLIES(a, b)
+#endif
+
+// Convenience wrapper around v8::String::NewFromOneByte
+inline v8::Local<v8::String> OneByteString(v8::Isolate* isolate,
+                                           const char* data, int length = -1);
+
+}  // namespace xprofiler
+
+#endif /* XPROFILER_SRC_UTIL_H */

--- a/src/xprofiler.cc
+++ b/src/xprofiler.cc
@@ -54,5 +54,6 @@ NAN_MODULE_INIT(Initialize) {
   CREATE_JS_BINDING(addHttpStatusCode, AddHttpStatusCode)
 }
 
+// TODO(legendecas): declare context aware when ready.
 NODE_MODULE(xprofiler, Initialize)
 }  // namespace xprofiler

--- a/test/fixtures/command.test.js
+++ b/test/fixtures/command.test.js
@@ -180,16 +180,14 @@ exports = module.exports = function (logdir) {
     },
     {
       cmd: 'set_config',
-      options: { enable_log_uv_handles: false, log_level: 2, log_type: 1, enable_fatal_error_hook: false },
+      options: { enable_log_uv_handles: false, log_level: 2, log_type: 1 },
       xctlRules: [
         { key: 'data.enable_log_uv_handles', rule: { label: 'false', test: value => value === false } },
         { key: 'data.log_level', rule: /^2$/ },
         { key: 'data.log_type', rule: /^1$/ },
-        { key: 'data.enable_fatal_error_hook', rule: { label: 'false', test: value => value === false } },
       ],
       xprofctlRules(data) {
         return [new RegExp(`^X-Profiler 配置\\(pid ${data.pid}\\)成功:\n`
-          + '  - enable_fatal_error_hook: false\n'
           + '  - enable_log_uv_handles: false\n'
           + '  - log_level: 2\n'
           + '  - log_type: 1')


### PR DESCRIPTION
1. 将每个进程唯一的配置项包装在 `per_process::config_store` 中；
2. 限制性地暴露 config getter/setter（大部分 config 不需要从 c++ set），减少配置变动的暴露面、后续多线程实现更简便；
2. 去除了通过 xprofctl 设置 `enable_fatal_error_hook` 的能力：等到 xprofctl 能设置这个值时，时机已经过去了，这个设置其实是不生效的；
3. 增加 OneByteString helper，配置项 key 都是 ASCII 编码；
