### PR TITLE
feat: replace logbypass static storages with EnvironmentData

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,4 @@
 # http://clang.llvm.org/docs/ClangFormatStyleOptions.html
 BasedOnStyle: Google
-MaxEmptyLinesToKeep: 2
+DerivePointerAlignment: false
+MaxEmptyLinesToKeep: 1

--- a/binding.gyp
+++ b/binding.gyp
@@ -4,6 +4,7 @@
             "target_name": "xprofiler",
             "win_delay_load_hook": "false",
             "sources": [
+                "src/environment_data.cc",
                 "src/xprofiler.cc",
                 "src/configure.cc",
                 "src/logger.cc",

--- a/src/environment_data.cc
+++ b/src/environment_data.cc
@@ -3,6 +3,7 @@
 #include <memory>
 
 #include "util.h"
+#include "xpf_node.h"
 
 namespace xprofiler {
 using Nan::HandleScope;
@@ -40,14 +41,7 @@ EnvironmentData* EnvironmentData::Create(v8::Isolate* isolate) {
 
   per_process::environment_data =
       std::unique_ptr<EnvironmentData>(new EnvironmentData(isolate));
-#if NODE_MAJOR_VERSION >= 10
-  // node::GetCurrentEnvironment is available since v10.x.
-  // We don't need to support multiple environments before v10.x, not releasing
-  // the per_process::environment_data is find.
-  node::Environment* env =
-      node::GetCurrentEnvironment(isolate->GetCurrentContext());
-  node::AtExit(env, AtExit, nullptr);
-#endif
+  xprofiler::AtExit(isolate, AtExit, nullptr);
 
   return per_process::environment_data.get();
 }

--- a/src/environment_data.cc
+++ b/src/environment_data.cc
@@ -1,0 +1,77 @@
+#include "environment_data.h"
+
+#include <memory>
+
+#include "util.h"
+
+namespace xprofiler {
+using Nan::HandleScope;
+using v8::Isolate;
+
+namespace per_process {
+// TODO(legendecas): environment registry.
+std::unique_ptr<EnvironmentData> environment_data;
+}  // namespace per_process
+
+EnvironmentData* EnvironmentData::GetCurrent() {
+  CHECK_NE(per_process::environment_data, nullptr);
+  return per_process::environment_data.get();
+}
+
+EnvironmentData* EnvironmentData::GetCurrent(v8::Isolate* isolate) {
+  // TODO(legendecas): environment registry.
+  CHECK_NE(per_process::environment_data, nullptr);
+  return per_process::environment_data.get();
+}
+
+EnvironmentData* EnvironmentData::GetCurrent(
+    const Nan::FunctionCallbackInfo<v8::Value>& info) {
+  // TODO(legendecas): environment registry.
+  CHECK_NE(per_process::environment_data, nullptr);
+  return per_process::environment_data.get();
+}
+
+EnvironmentData* EnvironmentData::Create(v8::Isolate* isolate) {
+  // TODO(legendecas): environment registry.
+  CHECK_EQ(per_process::environment_data, nullptr);
+
+  CHECK_EQ(isolate, Isolate::GetCurrent());
+  HandleScope scope;
+
+  per_process::environment_data =
+      std::unique_ptr<EnvironmentData>(new EnvironmentData(isolate));
+#if NODE_MAJOR_VERSION >= 10
+  // node::GetCurrentEnvironment is available since v10.x.
+  // We don't need to support multiple environments before v10.x, not releasing
+  // the per_process::environment_data is find.
+  node::Environment* env =
+      node::GetCurrentEnvironment(isolate->GetCurrentContext());
+  node::AtExit(env, AtExit, nullptr);
+#endif
+
+  return per_process::environment_data.get();
+}
+
+EnvironmentData::EnvironmentData(v8::Isolate* isolate) : isolate_(isolate) {
+  uv_loop_t* loop = node::GetCurrentEventLoop(isolate);
+  CHECK_EQ(0, uv_async_init(loop, &statistics_async_, CollectStatistics));
+  uv_unref(reinterpret_cast<uv_handle_t*>(&statistics_async_));
+}
+
+void EnvironmentData::AtExit(void* arg) {
+  // TODO(legendecas): environment registry.
+  per_process::environment_data.reset();
+}
+
+void EnvironmentData::SendCollectStatistics() {
+  uv_async_send(&statistics_async_);
+}
+
+void EnvironmentData::CollectStatistics(uv_async_t* handle) {
+  EnvironmentData* env_data =
+      ContainerOf(&EnvironmentData::statistics_async_, handle);
+  CollectMemoryStatistics(env_data);
+  CollectLibuvHandleStatistics(env_data);
+}
+
+}  // namespace xprofiler

--- a/src/environment_data.h
+++ b/src/environment_data.h
@@ -1,0 +1,48 @@
+#ifndef XPROFILER_SRC_ENVIRONMENT_DATA_H
+#define XPROFILER_SRC_ENVIRONMENT_DATA_H
+
+#include "logbypass/gc.h"
+#include "logbypass/heap.h"
+#include "logbypass/http.h"
+#include "logbypass/libuv.h"
+#include "nan.h"
+
+namespace xprofiler {
+
+class EnvironmentData {
+ public:
+  // TODO(legendecas): remove this no-args GetCurrent.
+  static EnvironmentData* GetCurrent();
+  static EnvironmentData* GetCurrent(v8::Isolate* isolate);
+  static EnvironmentData* GetCurrent(
+      const Nan::FunctionCallbackInfo<v8::Value>& info);
+  static EnvironmentData* Create(v8::Isolate* isolate);
+
+  void SendCollectStatistics();
+
+  inline v8::Isolate* isolate() { return isolate_; }
+
+  inline GcStatistics* gc_statistics() { return &gc_statistics_; }
+  inline HttpStatistics* http_statistics() { return &http_statistics_; }
+  inline MemoryStatistics* memory_statistics() { return &memory_statistics_; }
+  inline UvHandleStatistics* uv_handle_statistics() {
+    return &uv_handle_statistics_;
+  }
+
+ private:
+  static void AtExit(void* arg);
+  static void CollectStatistics(uv_async_t* handle);
+  EnvironmentData(v8::Isolate* isolate);
+
+  v8::Isolate* isolate_;
+  uv_async_t statistics_async_;
+
+  GcStatistics gc_statistics_;
+  MemoryStatistics memory_statistics_;
+  HttpStatistics http_statistics_;
+  UvHandleStatistics uv_handle_statistics_;
+};
+
+}  // namespace xprofiler
+
+#endif /* XPROFILER_SRC_ENVIRONMENT_DATA_H */

--- a/src/logbypass/cpu.cc
+++ b/src/logbypass/cpu.cc
@@ -15,7 +15,7 @@ namespace xprofiler {
   V(600)
 
 #define INIT_CPU_PERIOD(period)                     \
-  static double *cpu_##period = new double[period]; \
+  static double* cpu_##period = new double[period]; \
   static int cpu_##period##_array_index = 0;        \
   static int cpu_##period##_array_length = period;  \
   static int cpu_##period##_array_not_full = true;

--- a/src/logbypass/cpu.h
+++ b/src/logbypass/cpu.h
@@ -1,9 +1,9 @@
-#ifndef _SRC_LOGBYPASS_CPU_H
-#define _SRC_LOGBYPASS_CPU_H
+#ifndef XPROFILER_SRC_LOGBYPASS_CPU_H
+#define XPROFILER_SRC_LOGBYPASS_CPU_H
 
 namespace xprofiler {
 void SetNowCpuUsage();
 void WriteCpuUsageInPeriod(bool log_format_alinode);
 }  // namespace xprofiler
 
-#endif
+#endif /* XPROFILER_SRC_LOGBYPASS_CPU_H */

--- a/src/logbypass/gc.h
+++ b/src/logbypass/gc.h
@@ -1,44 +1,45 @@
-#ifndef _SRC_LOGBYPASS_GC_H
-#define _SRC_LOGBYPASS_GC_H
+#ifndef XPROFILER_SRC_LOGBYPASS_GC_H
+#define XPROFILER_SRC_LOGBYPASS_GC_H
 
 #include "nan.h"
+#include "xpf_mutex-inl.h"
 
 namespace xprofiler {
-typedef struct GcStatistics {
+class EnvironmentData;
+
+class GcStatistics {
  public:
   // total gc times
-  unsigned int total_gc_times = 0;
+  uint32_t total_gc_times = 0;
   // total gc duration
-  unsigned long total_gc_duration = 0;
-  unsigned long total_scavange_duration = 0;
-  unsigned long total_marksweep_duration = 0;
-  unsigned long total_incremental_marking_duration = 0;
+  uint32_t total_gc_duration = 0;
+  uint32_t total_scavange_duration = 0;
+  uint32_t total_marksweep_duration = 0;
+  uint32_t total_incremental_marking_duration = 0;
   // last record
-  unsigned long gc_time_during_last_record = 0;
-  unsigned long scavange_duration_last_record = 0;
-  unsigned long marksweep_duration_last_record = 0;
-  unsigned long incremental_marking_duration_last_record = 0;
+  uint32_t gc_time_during_last_record = 0;
+  uint32_t scavange_duration_last_record = 0;
+  uint32_t marksweep_duration_last_record = 0;
+  uint32_t incremental_marking_duration_last_record = 0;
+  uint64_t start = 0;
 
-  // record start
-  uint64_t &start() { return start_; }
+  Mutex mutex;
 
   // reset last record
   void reset() {
-    start_ = 0;
+    start = 0;
     gc_time_during_last_record = 0;
     scavange_duration_last_record = 0;
     marksweep_duration_last_record = 0;
     incremental_marking_duration_last_record = 0;
   }
+};
 
- private:
-  uint64_t start_ = 0;
-} gc_statistics_t;
+void InitGcStatusHooks();
+void WriteGcStatusToLog(EnvironmentData* env_data, bool log_format_alinode);
 
-int InitGcStatusHooks();
-void WriteGcStatusToLog(bool log_format_alinode);
-unsigned int TotalGcTimes();
-unsigned long TotalGcDuration();
+uint32_t TotalGcTimes();
+uint32_t TotalGcDuration();
 }  // namespace xprofiler
 
-#endif
+#endif /* XPROFILER_SRC_LOGBYPASS_GC_H */

--- a/src/logbypass/heap.h
+++ b/src/logbypass/heap.h
@@ -5,7 +5,8 @@
 #include "v8.h"
 
 namespace xprofiler {
-using v8::HeapStatistics;
+
+class EnvironmentData;
 
 #define INIT_SPACE_INFO(name)        \
   size_t name##_space_size = 0;      \
@@ -13,41 +14,10 @@ using v8::HeapStatistics;
   size_t name##_space_available = 0; \
   size_t name##_space_committed = 0;
 
-#define SET_SPACE_INFO(name)                                            \
-  if (strcmp(s.space_name(), #name) == 0) {                             \
-    heap_space_statistics->name##_size = s.space_size();                \
-    heap_space_statistics->name##_used = s.space_used_size();           \
-    heap_space_statistics->name##_available = s.space_available_size(); \
-    heap_space_statistics->name##_committed = s.physical_space_size();  \
-  }
-
-#define LOG_SPACE_INFO(name)                         \
-  heap_space_statistics->name##_space_size,          \
-      heap_space_statistics->name##_space_used,      \
-      heap_space_statistics->name##_space_available, \
-      heap_space_statistics->name##_space_committed
-
-#define COMMON_INFO_FORMATTER  \
-  "rss: %zu, "                 \
-  "heap_used: %zu, "           \
-  "heap_available: %zu, "      \
-  "heap_total: %zu, "          \
-  "heap_limit: %zu, "          \
-  "heap_executeable: %zu, "    \
-  "total_physical_size: %zu, " \
-  "malloced_memory: %zu, "     \
-  "amount_of_external_allocated_memory: %zu, "
-
-#define COMMON_INFO_FORMATTERX "memory_usage(byte) " COMMON_INFO_FORMATTER
-
-#define SPACE_INFO_FORMATTER(name)                            \
-#name "_space_size: %zu, " #name "_space_used: %zu, " #name \
-        "_space_available: %zu, " #name "_space_committed: %zu, "
-
 // heap statistics struct
-typedef struct XprofilerHeapStatistics {
+struct XprofilerHeapStatistics {
  public:
-  HeapStatistics *handle() { return &heap_statistics_; }
+  v8::HeapStatistics* handle() { return &heap_statistics_; }
   size_t total_heap_size() { return heap_statistics_.total_heap_size(); }
   size_t used_heap_size() { return heap_statistics_.used_heap_size(); }
   size_t total_available_size() {
@@ -64,7 +34,7 @@ typedef struct XprofilerHeapStatistics {
 #if (NODE_MODULE_VERSION >= 72)
   size_t external_memory() { return heap_statistics_.external_memory(); }
 #else
-  size_t &external_memory() { return external_memory_; }
+  size_t& external_memory() { return external_memory_; }
 #endif
 
  private:
@@ -72,11 +42,11 @@ typedef struct XprofilerHeapStatistics {
   // external memory
   size_t external_memory_ = 0;
 #endif
-  HeapStatistics heap_statistics_;
-} heap_statistics_t;
+  v8::HeapStatistics heap_statistics_;
+};
 
 // heap space statistics struct
-typedef struct XprofilerHeapSpaceStatistics {
+struct XprofilerHeapSpaceStatistics {
   INIT_SPACE_INFO(new)
   INIT_SPACE_INFO(old)
   INIT_SPACE_INFO(code)
@@ -85,12 +55,15 @@ typedef struct XprofilerHeapSpaceStatistics {
   INIT_SPACE_INFO(read_only)          // needs v8 version >= 6.8
   INIT_SPACE_INFO(new_large_object)   // needs v8 version >= 6.9
   INIT_SPACE_INFO(code_large_object)  // needs v8 version >= 7.3
-} heap_space_statistics_t;
+};
 
-int InitMemoryAsyncCallback();
-void UnrefMemoryAsyncHandle();
-void GetMemoryInfo();
-void WriteMemoryInfoToLog(bool log_format_alinode);
+struct MemoryStatistics {
+  XprofilerHeapStatistics heap_statistics;
+  XprofilerHeapSpaceStatistics heap_space_statistics;
+};
+
+void CollectMemoryStatistics(EnvironmentData* env_data);
+void WriteMemoryInfoToLog(EnvironmentData* env_data, bool log_format_alinode);
 }  // namespace xprofiler
 
 #endif

--- a/src/logbypass/http.h
+++ b/src/logbypass/http.h
@@ -1,21 +1,36 @@
-#ifndef _SRC_LOGBYPASS_HTTP_H
-#define _SRC_LOGBYPASS_HTTP_H
+#ifndef XPROFILER_SRC_LOGBYPASS_HTTP_H
+#define XPROFILER_SRC_LOGBYPASS_HTTP_H
 
 #include "nan.h"
+#include "xpf_mutex-inl.h"
 
 namespace xprofiler {
-using Nan::FunctionCallbackInfo;
-using v8::Value;
 
-int InitHttpStatus();
-void WriteHttpStatus(bool log_format_alinode, uint32_t http_patch_timeout);
+class EnvironmentData;
+
+constexpr uint16_t kMaxHttpStatusCode = 1000;
+
+struct HttpStatistics {
+  Mutex mutex;
+  // http server
+  uint32_t live_http_request = 0;
+  uint32_t http_response_close = 0;
+  uint32_t http_response_sent = 0;
+  uint32_t http_request_timeout = 0;
+  uint32_t http_rt = 0;  // ms
+  // http status code: 0 ~ 999
+  uint32_t status_codes[kMaxHttpStatusCode] = {0};
+};
+
+void WriteHttpStatus(EnvironmentData* env_data, bool log_format_alinode,
+                     uint32_t http_patch_timeout);
 
 // javascript-accessible
-void AddLiveRequest(const FunctionCallbackInfo<Value> &info);
-void AddCloseRequest(const FunctionCallbackInfo<Value> &info);
-void AddSentRequest(const FunctionCallbackInfo<Value> &info);
-void AddRequestTimeout(const FunctionCallbackInfo<Value> &info);
-void AddHttpStatusCode(const FunctionCallbackInfo<Value> &info);
+void AddLiveRequest(const Nan::FunctionCallbackInfo<v8::Value>& info);
+void AddCloseRequest(const Nan::FunctionCallbackInfo<v8::Value>& info);
+void AddSentRequest(const Nan::FunctionCallbackInfo<v8::Value>& info);
+void AddRequestTimeout(const Nan::FunctionCallbackInfo<v8::Value>& info);
+void AddHttpStatusCode(const Nan::FunctionCallbackInfo<v8::Value>& info);
 }  // namespace xprofiler
 
-#endif
+#endif /* XPROFILER_SRC_LOGBYPASS_HTTP_H */

--- a/src/logbypass/libuv.h
+++ b/src/logbypass/libuv.h
@@ -1,7 +1,11 @@
-#ifndef _SRC_LOGBYPASS_LIBUV_H
-#define _SRC_LOGBYPASS_LIBUV_H
+#ifndef XPROFILER_SRC_LOGBYPASS_LIBUV_H
+#define XPROFILER_SRC_LOGBYPASS_LIBUV_H
+
+#include <stdint.h>
 
 namespace xprofiler {
+
+class EnvironmentData;
 
 #define HANDLE_DEFAULT_VALUE 0
 
@@ -13,7 +17,9 @@ namespace xprofiler {
   active_##name##_handles = HANDLE_DEFAULT_VALUE; \
   active_and_ref_##name##_handles = HANDLE_DEFAULT_VALUE;
 
-typedef struct UvHandleStatistics {
+struct UvHandleStatistics {
+  uint32_t active_handles = 0;
+
   INIT_UV_HANDLE(file)
   INIT_UV_HANDLE(tcp)
   INIT_UV_HANDLE(udp)
@@ -21,17 +27,17 @@ typedef struct UvHandleStatistics {
 
   // reset record
   void reset() {
+    active_handles = 0;
     RESET_UV_HANDLE(file)
     RESET_UV_HANDLE(tcp)
     RESET_UV_HANDLE(udp)
     RESET_UV_HANDLE(timer)
   }
-} uv_handle_statistics_t;
+};
 
-int InitLibuvAsyncCallback();
-void UnrefLibuvAsyncHandle();
-void GetLibuvHandles();
-void WriteLibuvHandleInfoToLog(bool log_format_alinode);
+void CollectLibuvHandleStatistics(EnvironmentData* env_data);
+void WriteLibuvHandleInfoToLog(EnvironmentData* env_data,
+                               bool log_format_alinode);
 }  // namespace xprofiler
 
-#endif
+#endif /* XPROFILER_SRC_LOGBYPASS_LIBUV_H */

--- a/src/logbypass/log.h
+++ b/src/logbypass/log.h
@@ -1,14 +1,11 @@
-#ifndef _SRC_LOGBYPASS_LOG_H
-#define _SRC_LOGBYPASS_LOG_H
+#ifndef XPROFILER_SRC_LOGBYPASS_LOG_H
+#define XPROFILER_SRC_LOGBYPASS_LOG_H
 
 #include "nan.h"
 
 namespace xprofiler {
-using Nan::FunctionCallbackInfo;
-using v8::Value;
-
 // javascript-accessible
-void RunLogBypass(const FunctionCallbackInfo<Value> &info);
+void RunLogBypass(const Nan::FunctionCallbackInfo<v8::Value>& info);
 }  // namespace xprofiler
 
-#endif
+#endif /* XPROFILER_SRC_LOGBYPASS_LOG_H */

--- a/src/util.h
+++ b/src/util.h
@@ -81,6 +81,34 @@ struct AssertionInfo {
 #define UNREACHABLE(...) \
   ERROR_AND_ABORT("Unreachable code reached" __VA_OPT__(": ") __VA_ARGS__)
 
+template <typename Inner, typename Outer>
+constexpr uintptr_t OffsetOf(Inner Outer::*field) {
+  return reinterpret_cast<uintptr_t>(&(static_cast<Outer*>(nullptr)->*field));
+}
+
+// The helper is for doing safe downcasts from base types to derived types.
+template <typename Inner, typename Outer>
+class ContainerOfHelper {
+ public:
+  inline ContainerOfHelper(Inner Outer::*field, Inner* pointer)
+      : pointer_(reinterpret_cast<Outer*>(reinterpret_cast<uintptr_t>(pointer) -
+                                          OffsetOf(field))) {}
+
+  template <typename TypeName>
+  inline operator TypeName*() const {
+    return static_cast<TypeName*>(pointer_);
+  }
+
+ private:
+  Outer* const pointer_;
+};
+
+template <typename Inner, typename Outer>
+constexpr ContainerOfHelper<Inner, Outer> ContainerOf(Inner Outer::*field,
+                                                      Inner* pointer) {
+  return ContainerOfHelper<Inner, Outer>(field, pointer);
+}
+
 // Convenience wrapper around v8::String::NewFromOneByte
 inline v8::Local<v8::String> OneByteString(v8::Isolate* isolate,
                                            const char* data, int length = -1);

--- a/src/xpf_mutex-inl.h
+++ b/src/xpf_mutex-inl.h
@@ -1,0 +1,25 @@
+#ifndef XPROFILER_SRC_MUTEX_INL_H
+#define XPROFILER_SRC_MUTEX_INL_H
+
+#include "util.h"
+#include "xpf_mutex.h"
+
+namespace xprofiler {
+
+Mutex::Mutex() { CHECK_EQ(0, uv_mutex_init(&mutex_)); }
+
+Mutex::~Mutex() { uv_mutex_destroy(&mutex_); }
+
+void Mutex::Lock() { uv_mutex_lock(&mutex_); }
+
+void Mutex::Unlock() { uv_mutex_unlock(&mutex_); }
+
+Mutex::ScopedLock::ScopedLock(const Mutex& mutex) : mutex_(mutex) {
+  uv_mutex_lock(&mutex_.mutex_);
+}
+
+Mutex::ScopedLock::~ScopedLock() { uv_mutex_unlock(&mutex_.mutex_); }
+
+}  // namespace xprofiler
+
+#endif /* XPROFILER_SRC_MUTEX_INL_H */

--- a/src/xpf_mutex.h
+++ b/src/xpf_mutex.h
@@ -1,0 +1,40 @@
+#ifndef XPROFILER_SRC_MUTEX_H
+#define XPROFILER_SRC_MUTEX_H
+
+#include "nan.h"
+
+namespace xprofiler {
+
+class Mutex {
+ public:
+  inline Mutex();
+  inline ~Mutex();
+  inline void Lock();
+  inline void Unlock();
+
+  Mutex(const Mutex&) = delete;
+  Mutex& operator=(const Mutex&) = delete;
+
+  class ScopedLock;
+  class ScopedUnlock;
+
+  class ScopedLock {
+   public:
+    inline explicit ScopedLock(const Mutex& mutex);
+    inline explicit ScopedLock(const ScopedUnlock& scoped_unlock);
+    inline ~ScopedLock();
+
+    ScopedLock(const ScopedLock&) = delete;
+    ScopedLock& operator=(const ScopedLock&) = delete;
+
+   private:
+    const Mutex& mutex_;
+  };
+
+ private:
+  mutable uv_mutex_t mutex_;
+};
+
+}  // namespace xprofiler
+
+#endif /* XPROFILER_SRC_MUTEX_H */

--- a/src/xpf_node.h
+++ b/src/xpf_node.h
@@ -1,0 +1,26 @@
+#ifndef XPROFILER_SRC_XPF_NODE_H
+#define XPROFILER_SRC_XPF_NODE_H
+
+#include "nan.h"
+
+namespace xprofiler {
+
+/**
+ * Node.js compatibility helpers
+ */
+
+inline void AtExit(v8::Isolate* isolate, void (*cb)(void* arg), void* arg) {
+#if NODE_MAJOR_VERSION >= 10
+  // node::GetCurrentEnvironment is available since v10.x.
+  // We don't need to support multiple environments before v10.x.
+  node::Environment* env =
+      node::GetCurrentEnvironment(isolate->GetCurrentContext());
+  node::AtExit(env, cb, arg);
+#else
+  node::AtExit(cb, arg);
+#endif
+}
+
+}  // namespace xprofiler
+
+#endif /* XPROFILER_SRC_XPF_NODE_H */

--- a/src/xprofiler.cc
+++ b/src/xprofiler.cc
@@ -1,5 +1,6 @@
 #include "commands/listener.h"
 #include "configure.h"
+#include "environment_data.h"
 #include "hooks/set_hooks.h"
 #include "library/common.h"
 #include "logbypass/http.h"
@@ -13,6 +14,7 @@ using Nan::GetFunction;
 using Nan::New;
 using Nan::Set;
 using v8::FunctionTemplate;
+using v8::Isolate;
 using v8::String;
 
 NODE_C_CTOR(Main) {
@@ -26,6 +28,9 @@ NODE_C_CTOR(Main) {
       GetFunction(New<FunctionTemplate>(native_func)).ToLocalChecked())
 
 NAN_MODULE_INIT(Initialize) {
+  Isolate* isolate = target->GetIsolate();
+  EnvironmentData::Create(isolate);
+
   // config
   CREATE_JS_BINDING(configure, Configure);
   CREATE_JS_BINDING(getConfig, GetConfig);


### PR DESCRIPTION
- Defines`EnvironmentData`. In this PR, a `per_process::environment_data` is used without dynamic registration support.
- Replaces static storage slots of logbypass statistics collection (gc, heap, http, libuv) with EnvironmentData slots.
- logbypass only sends one single uv_async signal to the JavaScript thread to collect heap and uv handles statistics.