### PR TITLE
feat: per-isolate heap profiler

### DIFF
--- a/src/commands/heapdump/heap_profiler.cc
+++ b/src/commands/heapdump/heap_profiler.cc
@@ -1,19 +1,21 @@
 #include "heap_profiler.h"
 
 #include "heap_snapshot.h"
+#include "util.h"
+#include "xpf_v8.h"
 
 namespace xprofiler {
-using Nan::HandleScope;
-using v8::HeapSnapshot;
 using v8::Isolate;
 
-HeapProfiler::HeapProfiler() {}
-HeapProfiler::~HeapProfiler() {}
-
-void HeapProfiler::TakeSnapshot(string filename) {
-  Isolate *isolate = Isolate::GetCurrent();
-  HandleScope scope;
-  const HeapSnapshot *snap = isolate->GetHeapProfiler()->TakeHeapSnapshot();
-  Snapshot::Serialize(snap, filename);
+void DeleteHeapSnapshot(const v8::HeapSnapshot* snapshot) {
+  const_cast<v8::HeapSnapshot*>(snapshot)->Delete();
 }
+
+void HeapProfiler::TakeSnapshot(v8::Isolate* isolate, std::string filename) {
+  HandleScope scope(isolate);
+  HeapSnapshotPointer snap =
+      HeapSnapshotPointer(isolate->GetHeapProfiler()->TakeHeapSnapshot());
+  HeapSnapshot::Serialize(std::move(snap), filename);
+}
+
 }  // namespace xprofiler

--- a/src/commands/heapdump/heap_profiler.h
+++ b/src/commands/heapdump/heap_profiler.h
@@ -1,18 +1,20 @@
-#ifndef _SRC_COMMANDS_HEAPDUMP_HEAP_PROFILER_H
-#define _SRC_COMMANDS_HEAPDUMP_HEAP_PROFILER_H
+#ifndef XPROFILER_SRC_COMMANDS_HEAPDUMP_HEAP_PROFILER_H
+#define XPROFILER_SRC_COMMANDS_HEAPDUMP_HEAP_PROFILER_H
 
 #include "nan.h"
+#include "util.h"
 #include "v8-profiler.h"
 
 namespace xprofiler {
-using std::string;
+void DeleteHeapSnapshot(const v8::HeapSnapshot* snapshot);
+
+using HeapSnapshotPointer =
+    DeleteFnPtr<const v8::HeapSnapshot, DeleteHeapSnapshot>;
 
 class HeapProfiler {
  public:
-  HeapProfiler();
-  virtual ~HeapProfiler();
-  static void TakeSnapshot(string filename);
+  static void TakeSnapshot(v8::Isolate* isolate, std::string filename);
 };
 }  // namespace xprofiler
 
-#endif  // NODE_HEAP_PROFILER_H
+#endif /* XPROFILER_SRC_COMMANDS_HEAPDUMP_HEAP_PROFILER_H */

--- a/src/commands/heapdump/heap_snapshot.h
+++ b/src/commands/heapdump/heap_snapshot.h
@@ -1,15 +1,14 @@
-#ifndef _SRC_COMMANDS_HEAPDUMP_HEAP_SNAPSHOT_H
-#define _SRC_COMMANDS_HEAPDUMP_HEAP_SNAPSHOT_H
+#ifndef XPROFILER_SRC_COMMANDS_HEAPDUMP_HEAP_SNAPSHOT_H
+#define XPROFILER_SRC_COMMANDS_HEAPDUMP_HEAP_SNAPSHOT_H
 
+#include "heap_profiler.h"
 #include "v8-profiler.h"
 
 namespace xprofiler {
-using std::string;
-using v8::HeapSnapshot;
-
-class Snapshot {
+class HeapSnapshot {
  public:
-  static void Serialize(const HeapSnapshot *profile, string filename);
+  static void Serialize(HeapSnapshotPointer profile, std::string filename);
 };
 }  // namespace xprofiler
-#endif  // NODE_SNAPSHOT_
+
+#endif /* XPROFILER_SRC_COMMANDS_HEAPDUMP_HEAP_SNAPSHOT_H */

--- a/src/commands/heapprofiler/sampling_heap_profiler.cc
+++ b/src/commands/heapprofiler/sampling_heap_profiler.cc
@@ -52,6 +52,7 @@ void SamplingHeapProfiler::StopSamplingHeapProfiling(v8::Isolate* isolate,
     Error("sampling_heap_profiler", "open file %s failed.", filename.c_str());
     return;
   }
+  HandleScope scope(isolate);
   // get allocationProfile
   std::unique_ptr<AllocationProfile> profile =
       std::unique_ptr<AllocationProfile>(
@@ -59,7 +60,7 @@ void SamplingHeapProfiler::StopSamplingHeapProfiling(v8::Isolate* isolate,
   // stop sampling heap profile
   isolate->GetHeapProfiler()->StopSamplingHeapProfiler();
 
-  AllocationProfile::Node *root = profile->GetRootNode();
+  AllocationProfile::Node* root = profile->GetRootNode();
   JSONWriter writer(outfile);
   writer.json_start();
   writer.json_objectstart("head");

--- a/src/commands/heapprofiler/sampling_heap_profiler.cc
+++ b/src/commands/heapprofiler/sampling_heap_profiler.cc
@@ -1,21 +1,18 @@
 #include "sampling_heap_profiler.h"
 
-#include "../../library/writer.h"
-#include "../../logger.h"
+#include "library/writer.h"
+#include "logger.h"
+#include "xpf_v8.h"
 
 namespace xprofiler {
-using Nan::HandleScope;
 using Nan::Utf8String;
 using std::ofstream;
 using v8::AllocationProfile;
 using v8::Isolate;
 
-SamplingHeapProfile::SamplingHeapProfile() {}
-SamplingHeapProfile::~SamplingHeapProfile() {}
-
-void TranslateAllocationProfile(AllocationProfile::Node *node,
-                                JSONWriter *writer) {
-  HandleScope scope;
+void TranslateAllocationProfile(Isolate* isolate, AllocationProfile::Node* node,
+                                JSONWriter* writer) {
+  HandleScope scope(isolate);
   writer->json_objectstart("callFrame");
   Utf8String function_name(node->name);
   Utf8String url(node->script_name);
@@ -27,7 +24,7 @@ void TranslateAllocationProfile(AllocationProfile::Node *node,
   writer->json_objectend();
 
   // add self size
-  int selfSize = 0;
+  size_t selfSize = 0;
   for (size_t i = 0; i < node->allocations.size(); i++) {
     AllocationProfile::Allocation alloc = node->allocations[i];
     selfSize += alloc.size * alloc.count;
@@ -38,38 +35,36 @@ void TranslateAllocationProfile(AllocationProfile::Node *node,
   writer->json_arraystart("children");
   for (size_t i = 0; i < node->children.size(); i++) {
     writer->json_start();
-    TranslateAllocationProfile(node->children[i], writer);
+    TranslateAllocationProfile(isolate, node->children[i], writer);
     writer->json_end();
   }
   writer->json_arrayend();
 }
 
-void SamplingHeapProfile::StartSamplingHeapProfiling() {
-  Isolate::GetCurrent()->GetHeapProfiler()->StartSamplingHeapProfiler();
+void SamplingHeapProfiler::StartSamplingHeapProfiling(v8::Isolate* isolate) {
+  isolate->GetHeapProfiler()->StartSamplingHeapProfiler();
 }
 
-void SamplingHeapProfile::StopSamplingHeapProfiling(string filename) {
-  HandleScope scope;
-  ofstream outfile;
-  outfile.open(filename, std::ios::out | std::ios::binary);
+void SamplingHeapProfiler::StopSamplingHeapProfiling(v8::Isolate* isolate,
+                                                     std::string filename) {
+  ofstream outfile(filename, std::ios::out | std::ios::binary);
   if (!outfile.is_open()) {
     Error("sampling_heap_profiler", "open file %s failed.", filename.c_str());
-    outfile.close();
     return;
   }
   // get allocationProfile
-  AllocationProfile *profile =
-      Isolate::GetCurrent()->GetHeapProfiler()->GetAllocationProfile();
+  std::unique_ptr<AllocationProfile> profile =
+      std::unique_ptr<AllocationProfile>(
+          isolate->GetHeapProfiler()->GetAllocationProfile());
+  // stop sampling heap profile
+  isolate->GetHeapProfiler()->StopSamplingHeapProfiler();
+
   AllocationProfile::Node *root = profile->GetRootNode();
   JSONWriter writer(outfile);
   writer.json_start();
   writer.json_objectstart("head");
-  TranslateAllocationProfile(root, &writer);
+  TranslateAllocationProfile(isolate, root, &writer);
   writer.json_objectend();
   writer.json_end();
-  outfile.close();
-  free(profile);
-  // stop sampling heap profile
-  Isolate::GetCurrent()->GetHeapProfiler()->StopSamplingHeapProfiler();
 }
 }  // namespace xprofiler

--- a/src/commands/heapprofiler/sampling_heap_profiler.h
+++ b/src/commands/heapprofiler/sampling_heap_profiler.h
@@ -1,19 +1,16 @@
-#ifndef _SRC_COMMANDS_HEAPPROFILER_SAMPLING_HEAP_PROFILER_H
-#define _SRC_COMMANDS_HEAPPROFILER_SAMPLING_HEAP_PROFILER_H
+#ifndef XPROFILER_SRC_COMMANDS_HEAPPROFILER_SAMPLING_HEAP_PROFILER_H
+#define XPROFILER_SRC_COMMANDS_HEAPPROFILER_SAMPLING_HEAP_PROFILER_H
 
 #include "nan.h"
 #include "v8-profiler.h"
 
 namespace xprofiler {
-using std::string;
-
-class SamplingHeapProfile {
+class SamplingHeapProfiler final {
  public:
-  SamplingHeapProfile();
-  virtual ~SamplingHeapProfile();
-  static void StartSamplingHeapProfiling();
-  static void StopSamplingHeapProfiling(string filename);
+  static void StartSamplingHeapProfiling(v8::Isolate* isolate);
+  static void StopSamplingHeapProfiling(v8::Isolate* isolate,
+                                        std::string filename);
 };
 
 }  // namespace xprofiler
-#endif
+#endif /* XPROFILER_SRC_COMMANDS_HEAPPROFILER_SAMPLING_HEAP_PROFILER_H */

--- a/src/util.h
+++ b/src/util.h
@@ -114,6 +114,15 @@ constexpr size_t arraysize(const T (&)[N]) {
   return N;
 }
 
+template <typename T, void (*function)(T*)>
+struct FunctionDeleter {
+  void operator()(T* pointer) const { function(pointer); }
+  using Pointer = std::unique_ptr<T, FunctionDeleter>;
+};
+
+template <typename T, void (*function)(T*)>
+using DeleteFnPtr = typename FunctionDeleter<T, function>::Pointer;
+
 // Convenience wrapper around v8::String::NewFromOneByte
 inline v8::Local<v8::String> OneByteString(v8::Isolate* isolate,
                                            const char* data, int length = -1);


### PR DESCRIPTION
- Renames `CHECK` in dump.cc to `CHECK_ERR` to prevent name conflicts with `CHECK` in util.h
- Refactor heap profiler and heap snapshot to be `isolate` specific operations.