### PR TITLE
feat: per-isolate dump actions

### DIFF
--- a/src/commands/dump.h
+++ b/src/commands/dump.h
@@ -1,14 +1,12 @@
-#ifndef _SRC_COMMANDS_DUMP_H
-#define _SRC_COMMANDS_DUMP_H
+#ifndef XPROFILER_SRC_COMMANDS_DUMP_H
+#define XPROFILER_SRC_COMMANDS_DUMP_H
 
-#include "../library/common.h"
-#include "../library/utils.h"
+#include "library/common.h"
+#include "library/utils.h"
 #include "unordered_map"
 #include "vector"
 
 namespace xprofiler {
-using std::unordered_map;
-using std::vector;
 
 enum DumpAction {
   START_CPU_PROFILING,
@@ -21,37 +19,29 @@ enum DumpAction {
   NODE_REPORT
 };
 
-typedef unordered_map<int, bool> ActionMap;
-typedef unordered_map<string, bool> RequestMap;
-typedef unordered_map<int, vector<DumpAction>> ConflictMap;
-typedef unordered_map<int, DumpAction> DependentMap;
+using ActionMap = std::unordered_map<int, bool>;
+using RequestMap = std::unordered_map<std::string, bool>;
+using ConflictMap = std::unordered_map<int, std::vector<DumpAction>>;
+using DependentMap = std::unordered_map<int, DumpAction>;
 
-typedef struct BaseDumpData {
-  string traceid;
+struct BaseDumpData {
+  std::string traceid;
   DumpAction action;
   int profiling_time;
   bool run_once = true;
-} dump_data_t;
+};
 
-typedef struct CpuProfilerDumpData : BaseDumpData {
-  string title = "xprofiler";
-} cpuprofile_dump_data_t;
+struct CpuProfilerDumpData : BaseDumpData {
+  std::string title = "xprofiler";
+};
 
-typedef struct HeapdumpData : BaseDumpData {
-} heapdump_data_t;
+struct HeapdumpDumpData : BaseDumpData {};
 
-typedef struct SamplingHeapProfilerDumpData : BaseDumpData {
-} sampling_heapprofiler_dump_data_t;
+struct SamplingHeapProfilerDumpData : BaseDumpData {};
 
-typedef struct GcProfilerDumpData : BaseDumpData {
-} gcprofiler_dump_data_t;
+struct GcProfilerDumpData : BaseDumpData {};
 
-typedef struct NodeReportDumpData : BaseDumpData {
-} node_report_dump_data_t;
-
-int InitDumpAction();
-
-void UnrefDumpActionAsyncHandle();
+struct NodeReportDumpData : BaseDumpData {};
 
 COMMAND_CALLBACK(StartCpuProfiling);
 COMMAND_CALLBACK(StopCpuProfiling);
@@ -63,4 +53,4 @@ COMMAND_CALLBACK(StopGcProfiling);
 COMMAND_CALLBACK(GetNodeReport);
 }  // namespace xprofiler
 
-#endif
+#endif /* XPROFILER_SRC_COMMANDS_DUMP_H */

--- a/src/commands/listener.cc
+++ b/src/commands/listener.cc
@@ -28,16 +28,6 @@ void RunCommandsListener(const FunctionCallbackInfo<Value>& info) {
   }
   Info("init", "commands listener: listener thread created.");
 
-  // init dump action node isolate
-  rc = InitDumpAction();
-  if (rc != 0) {
-    ThrowTypeError("xprofiler: init dump action failed!");
-    info.GetReturnValue().Set(False());
-    return;
-  }
-  UnrefDumpActionAsyncHandle();
-  Info("init", "commands listener: dump action init succeed.");
-
   info.GetReturnValue().Set(True());
 }
 }  // namespace xprofiler

--- a/src/commands/listener.h
+++ b/src/commands/listener.h
@@ -1,5 +1,5 @@
-#ifndef _SRC_COMMANDS_LISTENER_H
-#define _SRC_COMMANDS_LISTENER_H
+#ifndef XPROFILER_SRC_COMMANDS_LISTENER_H
+#define XPROFILER_SRC_COMMANDS_LISTENER_H
 
 #include "nan.h"
 
@@ -11,4 +11,4 @@ using v8::Value;
 void RunCommandsListener(const FunctionCallbackInfo<Value>& info);
 }  // namespace xprofiler
 
-#endif
+#endif /* XPROFILER_SRC_COMMANDS_LISTENER_H */

--- a/src/commands/parser.h
+++ b/src/commands/parser.h
@@ -1,8 +1,8 @@
-#ifndef _SRC_PARSER_H
-#define _SRC_PARSER_H
+#ifndef XPROFILER_SRC_COMMANDS_PARSER_H
+#define XPROFILER_SRC_COMMANDS_PARSER_H
 
 namespace xprofiler {
 void ParseCmd(char* command);
 }
 
-#endif
+#endif /* XPROFILER_SRC_COMMANDS_PARSER_H */

--- a/src/commands/send.h
+++ b/src/commands/send.h
@@ -1,14 +1,13 @@
-#ifndef _SRC_COMMANDS_SEND_H
-#define _SRC_COMMANDS_SEND_H
+#ifndef XPROFILER_SRC_COMMANDS_SEND_H
+#define XPROFILER_SRC_COMMANDS_SEND_H
 
-#include "../library/json.hpp"
+#include "library/json.hpp"
 
 namespace xprofiler {
 using nlohmann::json;
-using std::string;
 
-void ErrorValue(string traceid, string message);
-void SuccessValue(string traceid, json data);
+void ErrorValue(std::string traceid, std::string message);
+void SuccessValue(std::string traceid, json data);
 }  // namespace xprofiler
 
-#endif
+#endif /* XPROFILER_SRC_COMMANDS_SEND_H */

--- a/src/hooks/fatal_error.h
+++ b/src/hooks/fatal_error.h
@@ -1,9 +1,11 @@
 #ifndef XPROFILER_SRC_HOOKS_FATAL_ERROR_H
 #define XPROFILER_SRC_HOOKS_FATAL_ERROR_H
 
+#include "nan.h"
+
 namespace xprofiler {
 [[noreturn]] void OnFatalError(const char* location, const char* message);
 void SetFatalErrorHandler(v8::Isolate* isolate);
-}
+}  // namespace xprofiler
 
 #endif /* XPROFILER_SRC_HOOKS_FATAL_ERROR_H */

--- a/src/library/utils.h
+++ b/src/library/utils.h
@@ -1,24 +1,23 @@
-#ifndef _SRC_LIBRARY_UTILS_H
-#define _SRC_LIBRARY_UTILS_H
+#ifndef XPROFILER_SRC_LIBRARY_UTILS_H
+#define XPROFILER_SRC_LIBRARY_UTILS_H
 
-#include "../logger.h"
 #include "error.h"
 #include "json.hpp"
+#include "logger.h"
 
 namespace xprofiler {
 using nlohmann::json;
-using std::string;
 
 void Sleep(int seconds);
 
-string FmtMessage(const char* format, ...);
+std::string FmtMessage(const char* format, ...);
 
-string RandNum();
+std::string RandNum();
 
-string ConvertTime(string format);
+std::string ConvertTime(std::string format);
 
 template <typename T>
-T GetJsonValue(json data, string key, XpfError& err) {
+T GetJsonValue(json data, std::string key, XpfError& err) {
   T result = T();
   try {
     result = data[key].get<T>();
@@ -37,4 +36,4 @@ T GetJsonValue(json data, string key, XpfError& err) {
 }
 }  // namespace xprofiler
 
-#endif
+#endif /* XPROFILER_SRC_LIBRARY_UTILS_H */


### PR DESCRIPTION
Refactors dump actions' assumptions on a single isolate per process.

Note that this PR doesn't change the fact that the dump action can only start one single profiling at once for a single process, and probably never going to change that.
