### PR TITLE
Release v1.4.0

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -34,6 +34,7 @@ jobs:
 
     - name: Install Dependencies
       run: npm install
+      if: ${{ matrix.ci-type.os != 'windows-latest' || matrix.node-version != 8  }}
 
     - name: Continuous Integration
       run: npm run ci || (sleep 60 && npm run ci) || (sleep 60 && npm run ci)

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -33,7 +33,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
 
     - name: Install Dependencies
-      run: npm i -g npminstall && npminstall
+      run: npm install
 
     - name: Continuous Integration
       run: npm run ci || (sleep 60 && npm run ci) || (sleep 60 && npm run ci)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xprofiler",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "node.js addon to output runtime logs",
   "bin": {
     "xprofctl": "bin/xprofctl"

--- a/scripts/7u.js
+++ b/scripts/7u.js
@@ -3,12 +3,12 @@
 const build = require('./build');
 
 const nodeVersions = [
-  'node-v12.22.7',
+  'node-v12.22.11',
   'node-v13.14.0',
-  'node-v14.18.2',
+  'node-v14.19.1',
   'node-v15.14.0',
-  'node-v16.13.1',
-  'node-v17.2.0',
+  'node-v16.14.2',
+  'node-v17.7.2',
 ];
 
 build(nodeVersions);

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -7,12 +7,12 @@ const nodeVersions = [
   'node-v9.11.2',
   'node-v10.24.1',
   'node-v11.15.0',
-  'node-v12.22.7',
+  'node-v12.22.11',
   'node-v13.14.0',
-  'node-v14.18.2',
+  'node-v14.19.1',
   'node-v15.14.0',
-  'node-v16.13.1',
-  'node-v17.2.0',
+  'node-v16.14.2',
+  'node-v17.7.2',
 ];
 
 build(nodeVersions);


### PR DESCRIPTION
Commits:
* [f26e918] fix: get node version from macros
* [077f6e3] feat: enclose config slots in per process store
* [5278a3a] fix: va_list shouldn't be converted to nullptr
* [6848552] feat: init global variables once at dlopen
* [21ade0e] fix: logger va_list argument type
* [3718573] feat: replace logbypass static storages with EnvironmentData
* [c4ced63] fix: replace hex node module version with semantic version macros
* [391d395] feat: per-isolate node report
* [ae6ab8d] chore: optimize content structure (e.g. gcprofile)
* [f78cd6a] feat: per-isolate heap profiler
* [9a931d5] feat: per-isolate gc profiler
* [7184d68] style: pointer alignment
* [5a39e3f] test: check child process exit code
* [95ed727] feat: per-isolate cpu profiler
* [eb5fbc5] feat: print location and message on fatal error
* [b0b65d5] feat: per-isolate dump actions
* [93e4dce] fix:  ci failed on windows with vs2022
* [6b47602] feat: deterministic diagnostic file id generation
* [02d8b07] feat: join-able logbypass thread
* [46bf2cb] fix: stop request before clear environment_data
* [0937a36] feat: environment registry
* [b35e586] feat: context aware native module