### PR TITLE
feat: perform profiling actions on worker threads

### DIFF
--- a/bin/xprofctl
+++ b/bin/xprofctl
@@ -22,7 +22,7 @@ const normalYargs = yargs => yargs
   .hide('h');
 
 const args = yargs
-  .usage('$0 <action> -p <pid> [-t profiling_time]')
+  .usage('$0 <action> -p <pid> [-t profiling_time] [-w worker_thread_id]')
   // commands
   .command('start_cpu_profiling', '启动 cpu 采样', profilingYargs)
   .command('stop_cpu_profiling', '生成 cpuprofile', normalYargs)
@@ -52,6 +52,9 @@ const args = yargs
   .describe('p', '进程 pid')
   .alias('p', 'pid')
   .demandOption(['p'])
+  // thread id
+  .describe('w', '线程 id')
+  .alias('w', 'worker_thread_id')
   // examples
   .example('$0 start_cpu_profiling -p 29156', '触发进程 29156 开始进行 cpu 采样')
   .example('$0 check_version -p 29156', '获取进程 29156 使用的插件版本')
@@ -66,6 +69,7 @@ const args = yargs
 // get args
 const action = args['_'][0];
 const pid = args['pid'];
+const thread_id = args['worker_thread_id'] || 0;
 
 // send message
 const options = utils.getXctOptions(action, args, xctljosn);
@@ -74,7 +78,7 @@ if (!options.ok) {
   return;
 }
 
-xctl(pid, action, options.data)
+xctl(pid, thread_id, action, options.data)
   .then(data => {
     if (data.ok) {
       data = data.data;
@@ -85,7 +89,7 @@ xctl(pid, action, options.data)
       case 'list_environments':
         console.log(`X-Profiler 环境列表(pid ${pid}):`);
         for (const env of data.environments) {
-          console.log(`  - 线程(tid ${env.thread_id}): ${env.is_main_thread ? '主线程' : 'Worker 线程'} 已启动${env.uptime}秒`);
+          console.log(`  - 线程(tid ${env.thread_id}): ${env.is_main_thread ? '主线程' : 'Worker线程'} 已启动${env.uptime}秒`);
         }
         break;
       case 'get_config':

--- a/lib/xctl.js
+++ b/lib/xctl.js
@@ -176,7 +176,7 @@ function timeout(time, key) {
   }, time));
 }
 
-async function sendCommands(pid, command, /* istanbul ignore next */options = {}) {
+async function sendCommands(pid, thread_id, command, /* istanbul ignore next */options = {}) {
   /* istanbul ignore if */
   if (!command) {
     throw new Error('命令参数不能缺失！');
@@ -196,7 +196,7 @@ async function sendCommands(pid, command, /* istanbul ignore next */options = {}
   const sendTasks = [];
   // send message
   const ipcPath = composeXprofilerPath(pid);
-  sendTasks.push(createMessageConnection(pid, ipcPath, { traceid, cmd: command, options }));
+  sendTasks.push(createMessageConnection(pid, ipcPath, { traceid, cmd: command, thread_id, options }));
   sendTasks.push(timeout(expired, 'send'));
 
   // send message & check result

--- a/src/commands/dump.h
+++ b/src/commands/dump.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "commands/parser.h"
+#include "library/common.h"
 
 namespace xprofiler {
 
@@ -27,6 +28,7 @@ using DependentMap = std::unordered_map<int, DumpAction>;
 struct BaseDumpData {
   std::string traceid;
   DumpAction action;
+  ThreadId thread_id;
   int profiling_time;
   bool run_once = true;
 };

--- a/src/commands/parser.cc
+++ b/src/commands/parser.cc
@@ -22,8 +22,7 @@ using std::string;
         parsed, FmtMessage,                                           \
         [traceid](json data) { SuccessValue(traceid, data); },        \
         [traceid](string message) { ErrorValue(traceid, message); }); \
-    handled = true;                                                   \
-  }
+  } else
 
 void ParseCmd(char* command) {
   Debug("parser", "received command: %s", command);
@@ -35,12 +34,13 @@ void ParseCmd(char* command) {
     return;
   }
 
-  // handle cmd
-  bool handled = false;
-  string cmd = parsed["cmd"];
-
-  // get traceid
   XpfError err;
+  string cmd = GetJsonValue<string>(parsed, "cmd", err);
+  if (err.Fail()) {
+    ErrorValue("unknown",
+               FmtMessage("cmd shoule be passed in: %s", err.GetErrMessage()));
+    return;
+  }
   string traceid = GetJsonValue<string>(parsed, "traceid", err);
   if (err.Fail()) {
     ErrorValue("unknown", FmtMessage("traceid shoule be passed in: %s",
@@ -77,7 +77,7 @@ void ParseCmd(char* command) {
   HANDLE_COMMANDS(diag_report, GetNodeReport)
 
   // not match any commands
-  if (!handled) {
+  /* else */ {
     ErrorValue(traceid, FmtMessage("not support command: %s", cmd.c_str()));
   }
 }

--- a/src/commands/report/node_report.cc
+++ b/src/commands/report/node_report.cc
@@ -2,11 +2,14 @@
 
 #include <fstream>
 
+#include "environment_data.h"
+#include "environment_registry.h"
 #include "library/common.h"
 #include "library/utils.h"
 #include "library/writer.h"
 #include "logger.h"
 #include "platform/platform.h"
+#include "process_data.h"
 
 namespace xprofiler {
 using std::ios;
@@ -19,6 +22,14 @@ void NodeReport::WriteNodeReport(JSONWriter* writer, std::string location,
   writer->json_start();
 
   writer->json_keyvalue("pid", GetPid());
+  {
+    EnvironmentRegistry* registry = ProcessData::Get()->environment_registry();
+    EnvironmentRegistry::NoExitScope no_exit(registry);
+    EnvironmentData* data = registry->Get(isolate_);
+    if (data != nullptr) {
+      writer->json_keyvalue("thread_id", data->thread_id());
+    }
+  }
   writer->json_keyvalue("location", location);
   writer->json_keyvalue("message", message);
   writer->json_keyvalue("nodeVersion", NODE_VERSION);

--- a/src/environment_registry.cc
+++ b/src/environment_registry.cc
@@ -36,6 +36,18 @@ EnvironmentData* EnvironmentRegistry::Get(v8::Isolate* isolate) {
   return it->second.get();
 }
 
+EnvironmentData* EnvironmentRegistry::Get(ThreadId thread_id) {
+  CHECK(disallow_exit_);
+
+  for (auto it : *this) {
+    if (it->thread_id() == thread_id) {
+      return it;
+    }
+  }
+
+  return nullptr;
+}
+
 EnvironmentData* EnvironmentRegistry::GetMainThread() {
   CHECK(disallow_exit_);
 

--- a/src/environment_registry.h
+++ b/src/environment_registry.h
@@ -49,6 +49,7 @@ class EnvironmentRegistry {
   void Register(v8::Isolate* isolate, std::unique_ptr<EnvironmentData> env);
   std::unique_ptr<EnvironmentData> Unregister(v8::Isolate* isolate);
   EnvironmentData* Get(v8::Isolate* isolate);
+  EnvironmentData* Get(ThreadId thread_id);
   EnvironmentData* GetMainThread();
 
   Iterator begin();

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -19,8 +19,19 @@ const logdir = utils.createLogDir('logdir_command');
 const tmphome = utils.createLogDir('tmphome_command');
 const testConfig = commandTestFixture(logdir);
 const testFiles = [
-  { jspath: path.join(__dirname, './fixtures/blocking.js'), desc: 'when js main thread blocking' },
-  { jspath: path.join(__dirname, './fixtures/non-blocking.js'), desc: 'when js main thread non blocking' }
+  {
+    jspath: path.join(__dirname, './fixtures/blocking.js'),
+    desc: 'when js main thread blocking'
+  },
+  {
+    jspath: path.join(__dirname, './fixtures/non-blocking.js'),
+    desc: 'when js main thread non blocking'
+  },
+  {
+    jspath: path.join(__dirname, './fixtures/worker_blocking.js'),
+    desc: 'when js worker thread blocking',
+    threadId: 1,
+  },
 ];
 
 function convertOptions(options) {
@@ -35,103 +46,105 @@ function convertOptions(options) {
   return extra;
 }
 
-for (let i = 0; i < testConfig.length; i++) {
-  const { cmd, options = {}, profileRules, errored = false, xctlRules, xprofctlRules } = testConfig[i];
-  for (let j = 0; j < testFiles.length; j++) {
-    const { jspath, desc } = testFiles[j];
-    const title = `execute [${cmd}] with options: ${JSON.stringify(options)} ${desc}`;
-    describe(title, function () {
-      let resByXctl = '';
-      let resByXprofctl = '';
-      let pid = 0;
-      let exitInfo = { code: null, signal: null };
-      before(async function () {
-        mm(os, 'homedir', () => tmphome);
-        console.log(`[${moment().format('YYYY-MM-DD HH:mm:ss')}]`, 'start fork.');
-        const p = cp.fork(jspath, {
-          env: Object.assign({}, process.env, {
-            XPROFILER_LOG_DIR: logdir,
-            XPROFILER_UNIT_TEST_TMP_HOMEDIR: tmphome,
-            XPROFILER_LOG_LEVEL: 2,
-            XPROFILER_LOG_TYPE: 1
-          })
+describe('commands', () => {
+  for (let i = 0; i < testConfig.length; i++) {
+    const { cmd, options = {}, profileRules, errored = false, xctlRules, xprofctlRules } = testConfig[i];
+    for (let j = 0; j < testFiles.length; j++) {
+      const { jspath, desc, threadId = 0 } = testFiles[j];
+      const title = `execute [${cmd}] on thread(${threadId}) with options: ${JSON.stringify(options)} ${desc}`;
+      describe(title, function () {
+        let resByXctl = '';
+        let resByXprofctl = '';
+        let pid = 0;
+        let exitInfo = { code: null, signal: null };
+        before(async function () {
+          mm(os, 'homedir', () => tmphome);
+          console.log(`[${moment().format('YYYY-MM-DD HH:mm:ss')}]`, 'start fork.');
+          const p = cp.fork(jspath, {
+            env: Object.assign({}, process.env, {
+              XPROFILER_LOG_DIR: logdir,
+              XPROFILER_UNIT_TEST_TMP_HOMEDIR: tmphome,
+              XPROFILER_LOG_LEVEL: 2,
+              XPROFILER_LOG_TYPE: 1
+            })
+          });
+          pid = p.pid;
+          await utils.sleep(4500);
+          // send cmd with xctl (function)
+          console.log(`[${moment().format('YYYY-MM-DD HH:mm:ss')}]`, 'send xctl cmd.');
+          resByXctl = await xctl(pid, threadId, cmd, options);
+          await utils.sleep(500);
+          // send cmd with xprofctl (cli)
+          const extra = convertOptions(options);
+          const nodeExe = os.platform() === 'win32' ? 'node ' : '';
+          console.log(`[${moment().format('YYYY-MM-DD HH:mm:ss')}]`, 'send xprofctl cmd.');
+          resByXprofctl = await exec(`${nodeExe}${xprofctl} ${cmd} -p ${pid} -w ${threadId}${extra}`, {
+            env: Object.assign({}, process.env, {
+              XPROFILER_UNIT_TEST_TMP_HOMEDIR: tmphome
+            })
+          });
+          resByXprofctl = resByXprofctl.stderr.trim() + resByXprofctl.stdout.trim();
+          console.log(`[${moment().format('YYYY-MM-DD HH:mm:ss')}]`, 'wait for child process done.');
+          exitInfo = await utils.getChildProcessExitInfo(p);
         });
-        pid = p.pid;
-        await utils.sleep(4500);
-        // send cmd with xctl (function)
-        console.log(`[${moment().format('YYYY-MM-DD HH:mm:ss')}]`, 'send xctl cmd.');
-        resByXctl = await xctl(pid, cmd, options);
-        await utils.sleep(500);
-        // send cmd with xprofctl (cli)
-        const extra = convertOptions(options);
-        const nodeExe = os.platform() === 'win32' ? 'node ' : '';
-        console.log(`[${moment().format('YYYY-MM-DD HH:mm:ss')}]`, 'send xprofctl cmd.');
-        resByXprofctl = await exec(`${nodeExe}${xprofctl} ${cmd} -p ${pid}${extra}`, {
-          env: Object.assign({}, process.env, {
-            XPROFILER_UNIT_TEST_TMP_HOMEDIR: tmphome
-          })
+
+        after(function () {
+          mm.restore();
+          if (i === testConfig.length - 1 && j === testFiles.length - 1) {
+            utils.cleanDir(logdir);
+            utils.cleanDir(tmphome);
+          }
         });
-        resByXprofctl = resByXprofctl.stderr.trim() + resByXprofctl.stdout.trim();
-        console.log(`[${moment().format('YYYY-MM-DD HH:mm:ss')}]`, 'wait for child process done.');
-        exitInfo = await utils.getChildProcessExitInfo(p);
-      });
 
-      after(function () {
-        mm.restore();
-        if (i === testConfig.length - 1 && j === testFiles.length - 1) {
-          utils.cleanDir(logdir);
-          utils.cleanDir(tmphome);
-        }
-      });
+        it(`child process should be exited with code 0`, function () {
+          console.log(`[${moment().format('YYYY-MM-DD HH:mm:ss')}]`, `exit info: ${JSON.stringify(exitInfo)}`);
+          utils.checkChildProcessExitInfo(expect, exitInfo);
+        });
 
-      it(`child process should be exited with code 0`, function () {
-        console.log(`[${moment().format('YYYY-MM-DD HH:mm:ss')}]`, `exit info: ${JSON.stringify(exitInfo)}`);
-        utils.checkChildProcessExitInfo(expect, exitInfo);
-      });
+        it(`response with xctl should be ok`, function () {
+          console.log('xtcl:', JSON.stringify(resByXctl));
+          expect(resByXctl).to.be.ok();
+          expect(typeof resByXctl === 'object').to.be.ok();
+          expect(resByXctl['traceid']).to.be.ok();
+          if (errored) {
+            expect(resByXctl['ok']).not.to.be.ok();
+          } else {
+            expect(resByXctl['ok']).to.be.ok();
+          }
+        });
 
-      it(`response with xctl should be ok`, function () {
-        console.log('xtcl:', JSON.stringify(resByXctl));
-        expect(resByXctl).to.be.ok();
-        expect(typeof resByXctl === 'object').to.be.ok();
-        expect(resByXctl['traceid']).to.be.ok();
-        if (errored) {
-          expect(resByXctl['ok']).not.to.be.ok();
-        } else {
-          expect(resByXctl['ok']).to.be.ok();
-        }
-      });
+        it(`response with xprofctl should be ok`, function () {
+          console.log('xprofctl:', resByXprofctl);
+          // expect(resByXprofctl).to.be.ok();
+          expect(typeof resByXprofctl === 'string').to.be.ok();
+        });
 
-      it(`response with xprofctl should be ok`, function () {
-        console.log('xprofctl:', resByXprofctl);
-        // expect(resByXprofctl).to.be.ok();
-        expect(typeof resByXprofctl === 'string').to.be.ok();
-      });
+        it(`response value should be ok`, function () {
+          describe(title, function () {
+            const data = { pid, threadId, logdir };
+            const rules = typeof xctlRules === 'function' ? xctlRules(data) : xctlRules;
+            for (const rule of rules) {
+              const value = utils.getNestingValue(resByXctl, rule.key);
+              it(`response.${rule.key}: ${value} should be ${rule.rule.label || rule.rule}`, function () {
+                expect(rule.rule.test(value)).to.be.ok();
+              });
 
-      it(`response value should be ok`, function () {
-        describe(title, function () {
-          const data = { pid, logdir };
-          const rules = typeof xctlRules === 'function' ? xctlRules(data) : xctlRules;
-          for (const rule of rules) {
-            const value = utils.getNestingValue(resByXctl, rule.key);
-            it(`response.${rule.key}: ${value} should be ${rule.rule.label || rule.rule}`, function () {
-              expect(rule.rule.test(value)).to.be.ok();
-            });
-
-            // check dump file
-            if (profileRules && typeof profileRules === 'object') {
-              const profile = JSON.parse(fs.readFileSync(resByXctl.data.filepath, 'utf8'));
-              checkProfile(profileRules, profile);
+              // check dump file
+              if (profileRules && typeof profileRules === 'object') {
+                const profile = JSON.parse(fs.readFileSync(resByXctl.data.filepath, 'utf8'));
+                checkProfile(profileRules, profile);
+              }
             }
-          }
 
-          for (const rule of xprofctlRules(data)) {
-            const value = resByXprofctl;
-            it(`${JSON.stringify(value)} should be ${rule}`, function () {
-              expect(rule.test(value)).to.be.ok();
-            });
-          }
+            for (const rule of xprofctlRules(data)) {
+              const value = resByXprofctl;
+              it(`${JSON.stringify(value)} should be ${rule}`, function () {
+                expect(rule.test(value)).to.be.ok();
+              });
+            }
+          });
         });
       });
-    });
+    }
   }
-}
+});

--- a/test/fixtures/command.test.js
+++ b/test/fixtures/command.test.js
@@ -147,6 +147,7 @@ const gcprofile = {
 
 const diag = {
   pid: REGEXP_NUMBER,
+  thread_id: REGEXP_NUMBER,
   location: /^([\w\s()-:]+|)$/,
   message: /^([\w\s()-:]+|)$/,
   nodeVersion: new RegExp(`^${process.version}$`),
@@ -184,13 +185,22 @@ exports = module.exports = function (logdir) {
     {
       cmd: 'list_environments',
       xctlRules: [
-        { key: 'data.environments.0.is_main_thread', rule: { label: 'true', test: value => value === true } },
-        { key: 'data.environments.0.thread_id', rule: { label: 'number', test: value => typeof value === 'number' } },
-        { key: 'data.environments.0.uptime', rule: { label: 'number', test: value => typeof value === 'number' } },
+        {
+          key: 'data.environments.0.is_main_thread',
+          rule: { label: 'boolean', test: value => typeof value === 'boolean' },
+        },
+        {
+          key: 'data.environments.0.thread_id',
+          rule: { label: 'number', test: value => typeof value === 'number' },
+        },
+        {
+          key: 'data.environments.0.uptime',
+          rule: { label: 'number', test: value => typeof value === 'number' },
+        },
       ],
       xprofctlRules(data) {
         return [new RegExp(`^X-Profiler 环境列表\\(pid ${data.pid}\\):\n`
-            + '  - 线程\\(tid 0\\): 主线程 已启动\\d+秒')];
+            + '(?:  - 线程\\(tid \\d+\\): (?:主|Worker)线程 已启动\\d+秒\n?)+')];
       }
     },
     {

--- a/test/fixtures/worker_blocking.js
+++ b/test/fixtures/worker_blocking.js
@@ -1,0 +1,37 @@
+'use strict';
+
+if (Number.parseInt(process.versions.node.split('.')[0], 10) <= 10) {
+  process.exit(0);
+}
+
+const workerThreads = require('worker_threads');
+const os = require('os');
+const mm = require('mm');
+const moment = require('moment');
+const { v4: uuid } = require('uuid');
+
+const traceid = uuid();
+
+if (process.env.XPROFILER_UNIT_TEST_TMP_HOMEDIR) {
+  mm(os, 'homedir', () => process.env.XPROFILER_UNIT_TEST_TMP_HOMEDIR);
+}
+
+const xprofiler = require('../../xprofiler');
+xprofiler.start({ check_throw: false });
+
+if (workerThreads.isMainThread) {
+  console.log(`[${moment().format('YYYY-MM-DD HH:mm:ss')}]`, traceid, 'blocking start.');
+  const w = new workerThreads.Worker(__filename, {
+    env: process.env,
+  });
+  w.on('exit', code => {
+    console.log(`[${moment().format('YYYY-MM-DD HH:mm:ss')}]`, traceid, 'worker exited', code);
+  });
+} else {
+  console.log(`[${moment().format('YYYY-MM-DD HH:mm:ss')}]`, traceid, 'blocking start.');
+
+  const start = Date.now();
+  while (Date.now() - start < 8000) { /** ignore */ }
+
+  console.log(`[${moment().format('YYYY-MM-DD HH:mm:ss')}]`, traceid, 'blocking done.');
+}

--- a/test/worker_threads.test.js
+++ b/test/worker_threads.test.js
@@ -35,6 +35,8 @@ let tmphome;
       proc = fork(path.join(__dirname, 'fixtures/worker.js'), {
         env: Object.assign({}, process.env, {
           XPROFILER_LOG_DIR: logdir,
+          XPROFILER_LOG_LEVEL: 2,
+          XPROFILER_LOG_TYPE: 1,
         }),
       });
       const [code, signal] = await once(proc, 'exit');
@@ -48,10 +50,13 @@ let tmphome;
       proc = fork(path.join(__dirname, 'fixtures/worker_indefinite.js'), {
         env: Object.assign({}, process.env, {
           XPROFILER_LOG_DIR: logdir,
+          XPROFILER_LOG_LEVEL: 2,
+          XPROFILER_LOG_TYPE: 1,
         }),
       });
       await sleep(2000);
-      const result = await xctl(proc.pid, 'list_environments', {
+      console.log('perform list_environments');
+      const result = await xctl(proc.pid, 0, 'list_environments', {
         logdir,
       });
       console.log('xctl result:', JSON.stringify(result, null, 2));


### PR DESCRIPTION
- Run `xprofctl [-w thread_id]` to specify thread to be profiled.
- Add positional parameter `threadId` to `xctl`.
- Add test case worker blocking in `test/command.test.js`.