### PR TITLE
feat: lock-free EnvironmentData::TryGetCurrent

### DIFF
--- a/src/environment_data.h
+++ b/src/environment_data.h
@@ -28,6 +28,9 @@ class EnvironmentData {
   static EnvironmentData* GetCurrent(v8::Isolate* isolate);
   static EnvironmentData* GetCurrent(
       const Nan::FunctionCallbackInfo<v8::Value>& info);
+  // Lock-free operation to get EnvironmentData for current thread, GetCurrent
+  // should be preferred in most cases.
+  static EnvironmentData* TryGetCurrent();
   static void Create(v8::Isolate* isolate);
 
   static void JsSetupEnvironmentData(


### PR DESCRIPTION
NodeReport should be lock-free to prevent unexpected dead-lock in abort/CHECK/v8::ApiCheck in arbitrary procedures.