### PR TITLE
feat: distinguish log types in different contexts

### DIFF
--- a/src/logger.cc
+++ b/src/logger.cc
@@ -137,7 +137,7 @@ static void Log(const LOG_LEVEL output_level, const char* type,
   // get log type
   switch (GetLogType()) {
     // tty
-    case LOG_TYPE::LOG_TO_TTL:
+    case LOG_TYPE::LOG_TO_TTY:
       printf("%s", tmp_log);
       WriteToFile(output_level, tmp_log);
       break;
@@ -161,23 +161,23 @@ void InitOnceLogger() {
   V(Error, LOG_ERROR)     \
   V(Debug, LOG_DEBUG)
 
-#define DEFINE_LOGGER(name, level)                           \
-  void name(const char* log_type, const char* format, ...) { \
-    va_list args;                                            \
-    va_start(args, format);                                  \
-    Log(LOG_LEVEL::level, log_type, 0, format, &args);       \
-    va_end(args);                                            \
+#define DEFINE_LOGGER(name, level)                            \
+  void name(const char* component, const char* format, ...) { \
+    va_list args;                                             \
+    va_start(args, format);                                   \
+    Log(LOG_LEVEL::level, component, 0, format, &args);       \
+    va_end(args);                                             \
   }
 NATIVE_LOGGERS(DEFINE_LOGGER);
 #undef DEFINE_LOGGER
 
-#define DEFINE_LOGGER(name, level)                                           \
-  void name##T(const char* log_type, ThreadId thread_id, const char* format, \
-               ...) {                                                        \
-    va_list args;                                                            \
-    va_start(args, format);                                                  \
-    Log(LOG_LEVEL::level, log_type, thread_id, format, &args);               \
-    va_end(args);                                                            \
+#define DEFINE_LOGGER(name, level)                                            \
+  void name##T(const char* component, ThreadId thread_id, const char* format, \
+               ...) {                                                         \
+    va_list args;                                                             \
+    va_start(args, format);                                                   \
+    Log(LOG_LEVEL::level, component, thread_id, format, &args);               \
+    va_end(args);                                                             \
   }
 NATIVE_LOGGERS(DEFINE_LOGGER);
 #undef DEFINE_LOGGER
@@ -190,11 +190,11 @@ NATIVE_LOGGERS(DEFINE_LOGGER);
   }                                                                            \
   EnvironmentData* env_data = EnvironmentData::GetCurrent(info);               \
                                                                                \
-  Local<String> log_type_string = To<String>(info[0]).ToLocalChecked();        \
-  Utf8String log_type(log_type_string);                                        \
+  Local<String> component_string = To<String>(info[0]).ToLocalChecked();       \
+  Utf8String component(component_string);                                      \
   Local<String> log_content_string = To<String>(info[1]).ToLocalChecked();     \
   Utf8String log_content(log_content_string);                                  \
-  Log(level, *log_type, env_data->thread_id(), *log_content);
+  Log(level, *component, env_data->thread_id(), *log_content);
 
 /* js binding logger */
 void JsInfo(const FunctionCallbackInfo<Value>& info) {

--- a/src/logger.h
+++ b/src/logger.h
@@ -7,18 +7,18 @@
 namespace xprofiler {
 // xprofiler logger
 enum LOG_LEVEL { LOG_INFO, LOG_ERROR, LOG_DEBUG };
-enum LOG_TYPE { LOG_TO_FILE, LOG_TO_TTL };
+enum LOG_TYPE { LOG_TO_FILE, LOG_TO_TTY };
 
 void InitOnceLogger();
 
 // normal external
-void Info(const char* log_type, const char* format, ...);
-void Error(const char* log_type, const char* format, ...);
-void Debug(const char* log_type, const char* format, ...);
+void Info(const char* component, const char* format, ...);
+void Error(const char* component, const char* format, ...);
+void Debug(const char* component, const char* format, ...);
 
-void InfoT(const char* log_type, ThreadId thread_id, const char* format, ...);
-void ErrorT(const char* log_type, ThreadId thread_id, const char* format, ...);
-void DebugT(const char* log_type, ThreadId thread_id, const char* format, ...);
+void InfoT(const char* component, ThreadId thread_id, const char* format, ...);
+void ErrorT(const char* component, ThreadId thread_id, const char* format, ...);
+void DebugT(const char* component, ThreadId thread_id, const char* format, ...);
 
 // javascript accessible
 void JsInfo(const Nan::FunctionCallbackInfo<v8::Value>& info);

--- a/test/logbypass.test.js
+++ b/test/logbypass.test.js
@@ -41,19 +41,19 @@ const casesForHttp = getTestCases('performance log correctly  XPROFILER_PATCH_HT
 // compose cases
 cases = cases.concat(casesForLibuv).concat(casesForHttp);
 
-function parseLog(logType, content, patt, alinode) {
-  console.log(`parse log ${logType}: ${JSON.stringify(content)}`);
+function parseLog(component, content, patt, alinode) {
+  console.log(`parse log ${component}: ${JSON.stringify(content)}`);
   const reg = /([^\s]*): (\d+(\.\d{0,2})?)/g;
   let matched;
   const res = { prefix: {}, detail: {} };
   while ((matched = patt.exec(content)) !== null) {
-    if (!matched || matched[2] !== logType) {
+    if (!matched || matched[2] !== component) {
       continue;
     }
 
     // set prefix;
     res.prefix.level = matched[1];
-    res.prefix.type = matched[2];
+    res.prefix.component = matched[2];
     res.prefix.pid = Number(matched[3]);
     let detail;
     if (alinode) {
@@ -106,18 +106,18 @@ for (const testCase of cases) {
         utils.checkChildProcessExitInfo(expect, exitInfo);
       });
 
-      const types = Object.keys(testCase.struct);
-      for (const type of types) {
-        describe(`parse log type [${type}] with content`, function () {
+      const components = Object.keys(testCase.struct);
+      for (const component of components) {
+        describe(`parse log component [${component}] with content`, function () {
           let parsed;
           before(function () {
-            parsed = parseLog(type, logContent, testCase.logparse, testCase.alinode);
+            parsed = parseLog(component, logContent, testCase.logparse, testCase.alinode);
           });
 
           it(`log prefix shoule be ok`, function () {
             const prefix = parsed.prefix;
             expect(/^info$|^error$|^debug$/.test(prefix.level)).to.be.ok();
-            expect(new RegExp(`^${type}$`).test(prefix.type)).to.be.ok();
+            expect(new RegExp(`^${component}$`).test(prefix.component)).to.be.ok();
             expect(prefix.pid).to.be(pid);
             if (testCase.alinode) {
               return;
@@ -127,15 +127,15 @@ for (const testCase of cases) {
             expect(Number.isInteger(prefix.tid)).to.be.ok();
           });
 
-          const struct = testCase.struct[type];
-          it(`type [${type}] should have keys ${Object.keys(struct)}`, function () {
+          const struct = testCase.struct[component];
+          it(`component [${component}] should have keys ${Object.keys(struct)}`, function () {
             const detail = parsed.detail;
             expect(utils.objKeyEqual(detail, struct)).to.be.ok();
           });
 
-          it(`type [${type}] should as expected`, function () {
+          it(`component [${component}] should as expected`, function () {
             const detail = parsed.detail;
-            describe(`${testCase.title} ${target.title}: ${type}`, function () {
+            describe(`${testCase.title} ${target.title}: ${component}`, function () {
               for (const key of Object.keys(detail)) {
                 const key2 = utils.formatKey(key);
                 const regexp = key2 !== key ? struct[key2].regexp : struct[key2];


### PR DESCRIPTION
- Rename the first parameter of `Info`/`Debu`/`Erro` to be `component` instead of `type` to be distinguished with LOG_TYPE enum.