### PR TITLE
Release 1.5.0@next

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,7 +18,7 @@ jobs:
           {os: "macos-latest", arch: "x64"},
           {os: "ubuntu-latest", arch: "x64"},
         ]
-        node-version: [ 8, 10, 12, 14, 16, 17 ]
+        node-version: [ 8, 10, 12, 14, 16, 18 ]
     steps:
     - name: Checkout Git Source
       uses: actions/checkout@master

--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ xprofiler 插件支持三大主流操作系统：
 - v15.x
 - v16.x
 - v17.x
+- v18.x
 
-更低的版本因为已经不在官方 LTS 计划中，故正常情况下不再支持。
+更低的版本因为在此项目创建时已经不在官方 LTS 计划中，故正常情况下不再支持。
 
 
 ## II. 快速开始
@@ -194,7 +195,7 @@ copyright 2019
 
 ## III. 插件架构和实现原理
 
-// TODO
+参见 [文档 - 整体架构](https://www.yuque.com/hyj1991/easy-monitor/architecture)
 
 
 ## IV. 稳定性

--- a/nyc.config.js
+++ b/nyc.config.js
@@ -1,12 +1,18 @@
 'use strict';
 
+const { testWorkerThreads } = require('./test/fixtures/utils');
 const defaultExclude = require('@istanbuljs/schema/default-exclude');
 const os = require('os');
 
-let platformExclude = [
-  os.platform() === 'win32' ? 'lib/clean.js' : ''
-];
+const ingores = [];
+if (os.platform() === 'win32') {
+  ingores.push('lib/clean.js');
+}
+
+if (!testWorkerThreads()) {
+  ingores.push('lib/worker_threads.js');
+}
 
 module.exports = {
-  exclude: platformExclude.concat(defaultExclude)
+  exclude: ingores.concat(defaultExclude)
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xprofiler",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "node.js addon to output runtime logs",
   "bin": {
     "xprofctl": "bin/xprofctl"

--- a/scripts/7u.js
+++ b/scripts/7u.js
@@ -3,12 +3,13 @@
 const build = require('./build');
 
 const nodeVersions = [
-  'node-v12.22.11',
+  'node-v12.22.12',
   'node-v13.14.0',
   'node-v14.19.1',
   'node-v15.14.0',
-  'node-v16.14.2',
-  'node-v17.7.2',
+  'node-v16.15.0',
+  'node-v17.9.0',
+  'node-v18.0.0',
 ];
 
 build(nodeVersions);

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -7,12 +7,13 @@ const nodeVersions = [
   'node-v9.11.2',
   'node-v10.24.1',
   'node-v11.15.0',
-  'node-v12.22.11',
+  'node-v12.22.12',
   'node-v13.14.0',
   'node-v14.19.1',
   'node-v15.14.0',
-  'node-v16.14.2',
-  'node-v17.7.2',
+  'node-v16.15.0',
+  'node-v17.9.0',
+  'node-v18.0.0',
 ];
 
 build(nodeVersions);

--- a/src/commands/coredumper/coredumper.h
+++ b/src/commands/coredumper/coredumper.h
@@ -1,5 +1,5 @@
 #ifndef XPROFILER_SRC_COMMANDS_COREDUMPER_H
-#define XPROFILER_SRC_COMMANDS_COREDUMOER_H
+#define XPROFILER_SRC_COMMANDS_COREDUMPER_H
 
 #include <string>
 
@@ -10,4 +10,4 @@ class Coredumper {
 };
 }  // namespace xprofiler
 
-#endif /* XPROFILER_SRC_COMMANDS_COREDUMOER_H */
+#endif /* XPROFILER_SRC_COMMANDS_COREDUMPER_H */

--- a/src/logbypass/libuv.cc
+++ b/src/logbypass/libuv.cc
@@ -84,7 +84,7 @@ void WriteLibuvHandleInfoToLog(EnvironmentData* env_data,
          uv_handle_statistics->active_handles);
   } else if (enable_log_uv_handles) {
     InfoT("uv", env_data->thread_id(),
-          "active_handles: %d, "
+          "active_handles: %ld, "
           "active_file_handles: %d, "
           "active_and_ref_file_handles: %d, "
           "active_tcp_handles: %d, "
@@ -103,7 +103,7 @@ void WriteLibuvHandleInfoToLog(EnvironmentData* env_data,
           uv_handle_statistics->active_timer_handles,
           uv_handle_statistics->active_and_ref_timer_handles);
   } else {
-    InfoT("uv", env_data->thread_id(), "[%ld] active_handles: %d",
+    InfoT("uv", env_data->thread_id(), "active_handles: %ld",
           uv_handle_statistics->active_handles);
   }
 }

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -27,13 +27,15 @@ const testFiles = [
   {
     jspath: path.join(__dirname, './fixtures/non-blocking.js'),
     desc: 'when js main thread non blocking'
-  },
-  {
+  }
+];
+if (utils.testWorkerThreads()) {
+  testFiles.push({
     jspath: path.join(__dirname, './fixtures/worker_blocking.js'),
     desc: 'when js worker thread blocking',
     threadId: 1,
-  },
-];
+  });
+}
 
 function convertOptions(options) {
   let extra = '';

--- a/test/fixtures/utils.js
+++ b/test/fixtures/utils.js
@@ -146,3 +146,7 @@ exports.filterTestCaseByPlatform = function filterTestCaseByPlatform(list) {
 
   return list.filter(item => !item.platform || item.platform === os.platform());
 };
+
+exports.testWorkerThreads = function testWorkerThreads() {
+  return Number.parseInt(process.versions.node.split('.')[0], 10) > 10;
+};

--- a/test/fixtures/worker.js
+++ b/test/fixtures/worker.js
@@ -1,6 +1,8 @@
 'use strict';
 
-if (Number.parseInt(process.versions.node.split('.')[0], 10) <= 10) {
+const { testWorkerThreads } = require('./utils');
+
+if (!testWorkerThreads()) {
   process.exit(0);
 }
 

--- a/test/fixtures/worker_blocking.js
+++ b/test/fixtures/worker_blocking.js
@@ -1,6 +1,8 @@
 'use strict';
 
-if (Number.parseInt(process.versions.node.split('.')[0], 10) <= 10) {
+const { testWorkerThreads } = require('./utils');
+
+if (!testWorkerThreads()) {
   process.exit(0);
 }
 

--- a/test/fixtures/worker_indefinite.js
+++ b/test/fixtures/worker_indefinite.js
@@ -1,6 +1,8 @@
 'use strict';
 
-if (Number.parseInt(process.versions.node.split('.')[0], 10) <= 10) {
+const { testWorkerThreads } = require('./utils');
+
+if (!testWorkerThreads()) {
   process.exit(0);
 }
 
@@ -23,5 +25,5 @@ if (workerThreads.isMainThread) {
     console.log('worker exited', code);
   });
 } else {
-  setInterval(() => {}, 1000);
+  setInterval(() => { }, 1000);
 }


### PR DESCRIPTION
Notable:

* Drop support for `node-v8.x` ~ `node-v11.x`
* Suppotr `node-v18.x`
* Support output `worker_threads` info
* Support `xprofctl generate_coredump -p <pid>`

Commits:

* [0ddefbf] feat: support generate core by xprofctl
* [b5c4b58] fix: ensure logger dtor order
* [3918eff] fix: uninstall gc callbacks at exit
* [f2c1109] fix: use EnvironmentData::TryGetCurrent in report
* [74b7090] feat: distinguish log types in different contexts
* [1c6842b] fix: clang-format failed on darwin
* [e928c9c] feat: lock-free EnvironmentData::TryGetCurrent
* [c87754e] feat: perform profiling actions on worker threads
* [6a3f139] fix: uptime should be measured in seconds
* [f5ff22b] feat: xctl command list_environments
* [3c50958] fix: worker_threads uptime
* [6242c54] feat: logbypass on worker threads
* [9a59ce8] fix: allow EnvironmentRegistry::Get after at-exit
* [4a5ed5f] feat: context aware native module
* [c114f45] feat: environment registry