### PR TITLE
chore: remove useless code

### DIFF
--- a/.autod.conf.js
+++ b/.autod.conf.js
@@ -34,9 +34,5 @@ module.exports = {
     './demo.js',
     './nyc.config.js',
   ],
-  semver: [
-    'eslint@6',
-    'mocha@7',
-    'yargs@15',
-  ]
+  semver: []
 };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "pack-7u": "node scripts/7u.js",
     "pack-8u": "node scripts/8u.js",
     "copy": "node scripts/copy.js",
-    "build": "npm run lint && node-pre-gyp rebuild",
+    "build": "node-pre-gyp rebuild",
     "format": "clang-format --version && clang-format -i --glob=\"src/**/!(report_win)[.h|.cc]\"",
     "lint": "npm run format && eslint --fix xprofiler.js \"test/**/*.js\" lib/*.js patch/*.js bin/xprofctl scripts/**/*.js",
     "test": "mocha -t 0 -R spec test/*.test.js test/patch/*.test.js",

--- a/package.json
+++ b/package.json
@@ -57,21 +57,21 @@
   "homepage": "https://github.com/X-Profiler/xprofiler#readme",
   "dependencies": {
     "@xprofiler/node-pre-gyp": "^1.0.9",
-    "moment": "^2.29.1",
+    "moment": "^2.29.3",
     "nan": "^2.15.0",
     "uuid": "^8.3.2",
-    "yargs": "^15.4.1"
+    "yargs": "^17.4.1"
   },
   "devDependencies": {
     "@istanbuljs/schema": "^0.1.3",
     "autod": "^3.1.2",
-    "clang-format": "1.6.0",
+    "clang-format": "^1.8.0",
     "codecov": "^3.8.3",
-    "eslint": "^6.8.0",
+    "eslint": "^8.14.0",
     "expect.js": "^0.3.1",
     "formstream": "^1.1.1",
     "mm": "^3.2.0",
-    "mocha": "^7.2.0",
+    "mocha": "^10.0.0",
     "nyc": "^15.1.0",
     "tunnel-agent": "^0.6.0",
     "urllib": "^2.38.0"

--- a/scripts/8u.js
+++ b/scripts/8u.js
@@ -3,7 +3,7 @@
 const build = require('./build');
 
 const nodeVersions = [
-  'node-v18.0.0',
+  'node-v18.1.0',
 ];
 
 build(nodeVersions);

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -25,7 +25,8 @@ function execCmd(cmd) {
   cp.execSync(cmd, {
     env: process.env,
     cwd: path.join(__dirname, '../'),
-    stdio: 'inherit'
+    stdio: 'inherit',
+    shell: '/bin/bash',
   });
 }
 
@@ -49,11 +50,12 @@ module.exports = async versions => {
 
   for (const version of versions) {
     debug(`>>>>>>>> start build with ${version}`);
+    const tnvmPath = path.join(os.homedir(), '.tnvm/tnvm.sh');
     let npmBin = 'npm';
-    let change = `source ~/.bashrc && tnvm use ${version}`;
+    let change = `source ${tnvmPath} && tnvm use ${version}`;
     const nvmNodeVersion = /^node-v(.*)$/.exec(version)[1];
     if (isWindows) {
-      npmBin =  path.join(os.tmpdir(), '../../', `Roaming\\nvm\\v${nvmNodeVersion}\\npm.cmd`);
+      npmBin = path.join(os.tmpdir(), '../../', `Roaming\\nvm\\v${nvmNodeVersion}\\npm.cmd`);
       change = `nvm use ${nvmNodeVersion}`;
     }
 

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -9,7 +9,7 @@ const nodeVersions = [
   'node-v15.14.0',
   'node-v16.15.0',
   'node-v17.9.0',
-  'node-v18.0.0',
+  'node-v18.1.0',
 ];
 
 build(nodeVersions);

--- a/src/commands/cpuprofiler/cpu_profile.cc
+++ b/src/commands/cpuprofiler/cpu_profile.cc
@@ -10,9 +10,7 @@ using Nan::Utf8String;
 using std::ofstream;
 
 void CpuProfile::DeleteCpuProfile(const v8::CpuProfile* profile) {
-#if (NODE_MODULE_VERSION > NODE_8_0_MODULE_VERSION)
   const_cast<v8::CpuProfile*>(profile)->Delete();
-#endif
 }
 
 void CpuProfile::Serialize(v8::Isolate* isolate, CpuProfilePtr node,

--- a/src/commands/cpuprofiler/cpu_profiler.cc
+++ b/src/commands/cpuprofiler/cpu_profiler.cc
@@ -11,9 +11,7 @@ using v8::Local;
 using v8::String;
 
 void CpuProfiler::DeleteCpuProfiler(v8::CpuProfiler* profiler) {
-#if (NODE_MODULE_VERSION > NODE_8_0_MODULE_VERSION)
   profiler->Dispose();
-#endif
 }
 
 void CpuProfiler::StartProfiling(v8::Isolate* isolate, std::string t) {
@@ -38,11 +36,7 @@ void CpuProfiler::StopProfiling(v8::Isolate* isolate, std::string t,
 }
 
 CpuProfiler::CpuProfiler(v8::Isolate* isolate) : isolate_(isolate) {
-#if (NODE_MODULE_VERSION > NODE_8_0_MODULE_VERSION)
   cpu_profiler_ = CpuProfilerPtr(v8::CpuProfiler::New(Isolate::GetCurrent()));
-#else
-  cpu_profiler_ = CpuProfilerPtr(isolate->GetCpuProfiler());
-#endif
 }
 
 CpuProfiler::~CpuProfiler() {}

--- a/src/commands/report/javascript_stack.cc
+++ b/src/commands/report/javascript_stack.cc
@@ -5,15 +5,9 @@
 #include "xpf_v8.h"
 
 static const size_t kMaxFramesCount = 255;
-#if (NODE_MODULE_VERSION >= NODE_9_0_MODULE_VERSION)
 static const char* v8_states[] = {
     "JS",       "GC",    "PARSER",   "BYTECODE_COMPILER",
     "COMPILER", "OTHER", "EXTERNAL", "IDLE"};
-#else
-static const char* v8_states[] = {
-    "JS",       "GC",   "COMPILER", "OTHER",
-    "EXTERNAL", "IDLE", "PARSER",   "BYTECODE_COMPILER"};
-#endif
 
 namespace xprofiler {
 using Nan::Utf8String;
@@ -68,12 +62,8 @@ void NodeReport::SetJavaScriptStack(JSONWriter* writer, bool fatal_error) {
     else
       writer->json_keyvalue("pcAddress", "nullptr");
 
-#if (NODE_VERSION_AT_LEAST(10, 12, 0))
     // needs v8 version >= 6.8
     Local<StackFrame> frame = stack->GetFrame(isolate_, i);
-#else
-    Local<StackFrame> frame = stack->GetFrame(i);
-#endif
 
     Utf8String fn_name_s(frame->GetFunctionName());
     Utf8String script_name(frame->GetScriptName());

--- a/src/logbypass/heap.cc
+++ b/src/logbypass/heap.cc
@@ -49,11 +49,6 @@ void GetRss(size_t* rss) {
 
 void SetHeapStatistics(XprofilerHeapStatistics* heap_statistics) {
   GetHeapStatistics(heap_statistics->handle());
-#if (NODE_MODULE_VERSION < NODE_12_0_MODULE_VERSION)
-  Isolate* isolate = Isolate::GetCurrent();
-  heap_statistics->external_memory() =
-      isolate->AdjustAmountOfExternalAllocatedMemory(0);
-#endif
 }
 
 void SetHeapSpaceStatistics(

--- a/src/logbypass/heap.h
+++ b/src/logbypass/heap.h
@@ -31,17 +31,9 @@ struct XprofilerHeapStatistics {
     return heap_statistics_.total_physical_size();
   }
   size_t malloced_memory() { return heap_statistics_.malloced_memory(); }
-#if (NODE_MODULE_VERSION >= NODE_12_0_MODULE_VERSION)
   size_t external_memory() { return heap_statistics_.external_memory(); }
-#else
-  size_t& external_memory() { return external_memory_; }
-#endif
 
  private:
-#if (NODE_MODULE_VERSION < NODE_12_0_MODULE_VERSION)
-  // external memory
-  size_t external_memory_ = 0;
-#endif
   v8::HeapStatistics heap_statistics_;
 };
 

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -18,14 +18,6 @@ void CreateIpcClient(char* message);
 void SleepCrossPlatform(int seconds);
 std::string GetSep();
 int GetPid();
-// for node-v8.x & ndoe-v10.x
-#if (NODE_MODULE_VERSION < NODE_12_0_MODULE_VERSION)
-typedef struct {
-  int64_t tv_sec;
-  int32_t tv_usec;
-} uv_timeval64_t;
-int uv_gettimeofday(uv_timeval64_t* tv);
-#endif
 
 // node report
 std::string GetPcAddress(void* pc);

--- a/src/platform/unix/core/linux/thread_lister.cc
+++ b/src/platform/unix/core/linux/thread_lister.cc
@@ -35,6 +35,7 @@
 
 #include <stdio.h> /* needed for NULL on some powerpc platforms (?!) */
 #include <sys/prctl.h>
+#include <unistd.h>
 
 #include "linuxthreads.h"
 /* Include other thread listers here that define THREADS macro

--- a/src/platform/unix/utils.cc
+++ b/src/platform/unix/utils.cc
@@ -11,21 +11,6 @@ void SleepCrossPlatform(int seconds) { sleep(seconds); }
 std::string GetSep() { return "/"; }
 
 int GetPid() { return getpid(); }
-
-#if (NODE_MODULE_VERSION < NODE_12_0_MODULE_VERSION)
-// from libuv: uv/src/unix
-int uv_gettimeofday(uv_timeval64_t* tv) {
-  struct timeval time;
-
-  if (tv == NULL) return UV_EINVAL;
-
-  if (gettimeofday(&time, NULL) != 0) return -1;
-
-  tv->tv_sec = (int64_t)time.tv_sec;
-  tv->tv_usec = (int32_t)time.tv_usec;
-  return 0;
-}
-#endif
 }  // namespace xprofiler
 
 #endif

--- a/src/platform/win/utils_win.cc
+++ b/src/platform/win/utils_win.cc
@@ -10,24 +10,6 @@ void SleepCrossPlatform(int seconds) { Sleep(seconds * 1000); }
 std::string GetSep() { return "\\"; }
 
 int GetPid() { return getpid(); }
-
-#if (NODE_MODULE_VERSION < NODE_12_0_MODULE_VERSION)
-// from libuv: uv/src/unix
-int uv_gettimeofday(uv_timeval64_t* tv) {
-  const uint64_t epoch = (uint64_t)116444736000000000ULL;
-  FILETIME file_time;
-  ULARGE_INTEGER ularge;
-
-  if (tv == NULL) return UV_EINVAL;
-
-  GetSystemTimeAsFileTime(&file_time);
-  ularge.LowPart = file_time.dwLowDateTime;
-  ularge.HighPart = file_time.dwHighDateTime;
-  tv->tv_sec = (int64_t)((ularge.QuadPart - epoch) / 10000000L);
-  tv->tv_usec = (int32_t)(((ularge.QuadPart - epoch) % 10000000L) / 10);
-  return 0;
-}
-#endif
 }  // namespace xprofiler
 
 #endif

--- a/src/xpf_node.h
+++ b/src/xpf_node.h
@@ -10,15 +10,9 @@ namespace xprofiler {
  */
 
 inline void AtExit(v8::Isolate* isolate, void (*cb)(void* arg), void* arg) {
-#if NODE_MODULE_VERSION >= NODE_10_0_MODULE_VERSION
-  // node::GetCurrentEnvironment is available since v10.x.
-  // We don't need to support multiple environments before v10.x.
   node::Environment* env =
       node::GetCurrentEnvironment(isolate->GetCurrentContext());
   node::AtExit(env, cb, arg);
-#else
-  node::AtExit(cb, arg);
-#endif
 }
 
 }  // namespace xprofiler

--- a/src/xpf_v8.h
+++ b/src/xpf_v8.h
@@ -13,17 +13,10 @@ class HandleScope {
   v8::HandleScope scope_;
 
  public:
-#if NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION
   inline HandleScope(v8::Isolate* isolate) : scope_(isolate) {}
   inline static int NumberOfHandles(v8::Isolate* isolate) {
     return v8::HandleScope::NumberOfHandles(isolate);
   }
-#else
-  inline HandleScope(v8::Isolate* isolate) : scope() {}
-  inline static int NumberOfHandles(v8::Isolate* isolate) {
-    return v8::HandleScope::NumberOfHandles();
-  }
-#endif
 
  private:
   // Make it hard to create heap-allocated or illegal handle scopes by

--- a/test/log.test.js
+++ b/test/log.test.js
@@ -8,6 +8,7 @@ const moment = require('moment');
 const xprofiler = require('../xprofiler');
 const pack = require('../package.json');
 const utils = require('./fixtures/utils');
+const { threadId } = require('../lib/worker_threads');
 
 // clean logdir
 const log_dir = utils.createLogDir('logdir');
@@ -113,6 +114,12 @@ for (const testConfig of testConfigList) {
             it(`pid should be ${process.pid}`, function () {
               expect(Number(d.pid)).to.be(process.pid);
             });
+
+            if (testConfig.variant === 'xprofiler') {
+              it(`tid should be ${threadId}`, function () {
+                expect(Number(d.tid)).to.be(threadId);
+              });
+            }
 
             it(`content should be "${log.content}"`, function () {
               expect(d.detail).to.be(log.content);


### PR DESCRIPTION
由于 `xprofiler@2.x` 最小版本提升至 `node-v12.x`，此 PR 旨在移除一些已经无需使用的实现，具体为：

* 将 SRC 和 Node.js 版本相关的条件判断逻辑移除（涉及到 12.x 以下），使实现更加简洁