### PR TITLE
fix: ensure config dtor order

### DIFF
--- a/src/configure-inl.h
+++ b/src/configure-inl.h
@@ -4,50 +4,56 @@
 #include "configure.h"
 
 namespace xprofiler {
-std::string GetLogDir() { return per_process::config_store.log_dir; }
+std::string GetLogDir() { return ProcessData::Get()->config_store()->log_dir; }
 
-uint32_t GetLogInterval() { return per_process::config_store.log_interval; }
+uint32_t GetLogInterval() {
+  return ProcessData::Get()->config_store()->log_interval;
+}
 
-LOG_LEVEL GetLogLevel() { return per_process::config_store.log_level; }
+LOG_LEVEL GetLogLevel() {
+  return ProcessData::Get()->config_store()->log_level;
+}
 
-LOG_TYPE GetLogType() { return per_process::config_store.log_type; }
+LOG_TYPE GetLogType() { return ProcessData::Get()->config_store()->log_type; }
 
 bool GetFormatAsAlinode() {
-  return per_process::config_store.log_format_alinode;
+  return ProcessData::Get()->config_store()->log_format_alinode;
 }
 
 bool GetEnableLogUvHandles() {
-  return per_process::config_store.enable_log_uv_handles;
+  return ProcessData::Get()->config_store()->enable_log_uv_handles;
 }
 
 bool GetEnableFatalErrorHook() {
-  return per_process::config_store.enable_fatal_error_hook;
+  return ProcessData::Get()->config_store()->enable_fatal_error_hook;
 }
 
 bool GetEnableFatalErrorReport() {
-  return per_process::config_store.enable_fatal_error_report;
+  return ProcessData::Get()->config_store()->enable_fatal_error_report;
 }
 
 bool GetEnableFatalErrorCoredump() {
-  return per_process::config_store.enable_fatal_error_coredump;
+  return ProcessData::Get()->config_store()->enable_fatal_error_coredump;
 }
 
-bool GetPatchHttp() { return per_process::config_store.patch_http; }
+bool GetPatchHttp() { return ProcessData::Get()->config_store()->patch_http; }
 
 uint32_t GetPatchHttpTimeout() {
-  return per_process::config_store.patch_http_timeout;
+  return ProcessData::Get()->config_store()->patch_http_timeout;
 }
 
-bool GetCheckThrow() { return per_process::config_store.check_throw; }
+bool GetCheckThrow() { return ProcessData::Get()->config_store()->check_throw; }
 
 void SetLogLevel(LOG_LEVEL value) {
-  per_process::config_store.log_level = value;
+  ProcessData::Get()->config_store()->log_level = value;
 }
 
-void SetLogType(LOG_TYPE value) { per_process::config_store.log_type = value; }
+void SetLogType(LOG_TYPE value) {
+  ProcessData::Get()->config_store()->log_type = value;
+}
 
 void SetEnableLogUvHandles(bool value) {
-  per_process::config_store.enable_log_uv_handles = value;
+  ProcessData::Get()->config_store()->enable_log_uv_handles = value;
 }
 
 }  // namespace xprofiler

--- a/src/configure-inl.h
+++ b/src/configure-inl.h
@@ -2,6 +2,7 @@
 #define XPROFILER_SRC_CONFIGURE_INL_H
 
 #include "configure.h"
+#include "process_data.h"
 
 namespace xprofiler {
 std::string GetLogDir() { return ProcessData::Get()->config_store()->log_dir; }

--- a/src/configure.cc
+++ b/src/configure.cc
@@ -19,10 +19,6 @@ using v8::Object;
 using v8::String;
 using v8::Value;
 
-namespace per_process {
-ConfigStore config_store;
-}
-
 #define LOCAL_VALUE(key)     \
   Local<Value> key##_value = \
       Get(config, OneByteString(isolate, #key)).ToLocalChecked();
@@ -32,35 +28,37 @@ ConfigStore config_store;
   if (key##_value->IsString()) {                                           \
     Local<String> key##_string = To<String>(key##_value).ToLocalChecked(); \
     Utf8String key##_utf8string(key##_string);                             \
-    per_process::config_store.key = *key##_utf8string;                     \
+    ProcessData::Get()->config_store()->key = *key##_utf8string;           \
   }
 
-#define CONVERT_UINT32(key)                                                \
-  LOCAL_VALUE(key)                                                         \
-  if (key##_value->IsUint32()) {                                           \
-    per_process::config_store.key = To<uint32_t>(key##_value).ToChecked(); \
+#define CONVERT_UINT32(key)                    \
+  LOCAL_VALUE(key)                             \
+  if (key##_value->IsUint32()) {               \
+    ProcessData::Get()->config_store()->key =  \
+        To<uint32_t>(key##_value).ToChecked(); \
   }
 
 #define CONVERT_UINT32_WITH_TYPE(key, type)                       \
   LOCAL_VALUE(key)                                                \
   if (key##_value->IsUint32()) {                                  \
-    per_process::config_store.key =                               \
+    ProcessData::Get()->config_store()->key =                     \
         static_cast<type>(To<uint32_t>(key##_value).ToChecked()); \
   }
 
-#define CONVERT_BOOL(key)                                              \
-  LOCAL_VALUE(key)                                                     \
-  if (key##_value->IsBoolean()) {                                      \
-    per_process::config_store.key = To<bool>(key##_value).ToChecked(); \
+#define CONVERT_BOOL(key)                     \
+  LOCAL_VALUE(key)                            \
+  if (key##_value->IsBoolean()) {             \
+    ProcessData::Get()->config_store()->key = \
+        To<bool>(key##_value).ToChecked();    \
   }
 
 #define CONFIG_LOCAL_STRING(key, type)      \
   Set(config, OneByteString(isolate, #key), \
-      New<type>(per_process::config_store.key).ToLocalChecked());
+      New<type>(ProcessData::Get()->config_store()->key).ToLocalChecked());
 
 #define CONFIG_NATIVE_NUMBER(key, type)     \
   Set(config, OneByteString(isolate, #key), \
-      New<type>(per_process::config_store.key));
+      New<type>(ProcessData::Get()->config_store()->key));
 
 void Configure(const FunctionCallbackInfo<Value>& info) {
   Isolate* isolate = info.GetIsolate();

--- a/src/configure.cc
+++ b/src/configure.cc
@@ -1,5 +1,6 @@
 #include "configure.h"
 
+#include "process_data.h"
 #include "util-inl.h"
 
 namespace xprofiler {

--- a/src/configure.h
+++ b/src/configure.h
@@ -5,6 +5,7 @@
 #include "library/error.h"
 #include "logger.h"
 #include "nan.h"
+#include "process_data.h"
 
 namespace xprofiler {
 
@@ -45,10 +46,6 @@ class ConfigStore {
   bool enable_fatal_error_report = true;
   bool enable_fatal_error_coredump = false;
 };
-
-namespace per_process {
-extern ConfigStore config_store;
-}
 
 }  // namespace xprofiler
 

--- a/src/configure.h
+++ b/src/configure.h
@@ -5,7 +5,6 @@
 #include "library/error.h"
 #include "logger.h"
 #include "nan.h"
-#include "process_data.h"
 
 namespace xprofiler {
 

--- a/src/process_data.h
+++ b/src/process_data.h
@@ -1,6 +1,7 @@
 #ifndef XPROFILER_SRC_PROCESS_DATA_H
 #define XPROFILER_SRC_PROCESS_DATA_H
 
+#include "configure.h"
 #include "environment_data.h"
 #include "environment_registry.h"
 #include "logbypass/log.h"

--- a/src/process_data.h
+++ b/src/process_data.h
@@ -28,12 +28,16 @@ class ProcessData {
   EnvironmentRegistry* environment_registry() {
     return &environment_registry_;
   };
+
+  ConfigStore* config_store() { return &config_store_; }
+
   std::unique_ptr<LogByPass> log_by_pass;
   Mutex log_by_pass_mutex;
   Mutex logger_mutex;
 
  private:
   EnvironmentRegistry environment_registry_;
+  ConfigStore config_store_;
 };
 
 }  // namespace xprofiler


### PR DESCRIPTION
* 退出前 `logbypass` 在 `config_store` 之后 `Join` 会导致诸如 `logdir` 乱码的问题，收敛到 `ProcessData` 类中保证其在 `Join` 后销毁