### PR TITLE
fix: runtime version in report

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -26,7 +26,7 @@ function execCmd(cmd) {
     env: process.env,
     cwd: path.join(__dirname, '../'),
     stdio: 'inherit',
-    shell: '/bin/bash',
+    shell: isWindows ? undefined : '/bin/bash',
   });
 }
 
@@ -59,7 +59,7 @@ module.exports = async versions => {
       change = `nvm use ${nvmNodeVersion}`;
     }
 
-    const install = 'npm install';
+    const install = 'npm install --no-audit';
     const build = `${npmBin} run dep`;
     const pack = 'npx node-pre-gyp package && npx node-pre-gyp testpackage';
     const copy = `${npmBin} run copy`;

--- a/src/commands/report/node_report.cc
+++ b/src/commands/report/node_report.cc
@@ -30,7 +30,7 @@ void NodeReport::WriteNodeReport(JSONWriter* writer, std::string location,
   }
   writer->json_keyvalue("location", location);
   writer->json_keyvalue("message", message);
-  writer->json_keyvalue("nodeVersion", NODE_VERSION);
+  writer->json_keyvalue("nodeVersion", GetGlobalNodeVersion(isolate_));
   writer->json_keyvalue("osVersion", GetOsVersion());
   writer->json_keyvalue("loadTime", GetStartTime("%Y-%m-%d %H:%M:%S"));
   writer->json_keyvalue("dumpTime", ConvertTime("%Y-%m-%d %H:%M:%S"));

--- a/src/environment_data.cc
+++ b/src/environment_data.cc
@@ -199,9 +199,16 @@ void EnvironmentData::JsSetupEnvironmentData(
       data->Get(context, OneByteString(isolate, "isMainThread"))
           .ToLocalChecked()
           .As<Boolean>();
+  Local<v8::String> node_version =
+      data->Get(context, OneByteString(isolate, "nodeVersion"))
+          .ToLocalChecked()
+          .As<v8::String>();
 
   env_data->thread_id_ = thread_id->Value();
   env_data->is_main_thread_ = is_main_thread->Value();
+
+  Nan::Utf8String node_version_(node_version);
+  env_data->node_version_ = (*node_version_);
 }
 
 }  // namespace xprofiler

--- a/src/environment_data.cc
+++ b/src/environment_data.cc
@@ -207,8 +207,8 @@ void EnvironmentData::JsSetupEnvironmentData(
   env_data->thread_id_ = thread_id->Value();
   env_data->is_main_thread_ = is_main_thread->Value();
 
-  Nan::Utf8String node_version_(node_version);
-  env_data->node_version_ = (*node_version_);
+  Nan::Utf8String node_version_string(node_version);
+  env_data->node_version_ = (*node_version_string);
 }
 
 }  // namespace xprofiler

--- a/src/environment_data.h
+++ b/src/environment_data.h
@@ -53,6 +53,7 @@ class EnvironmentData {
 
   inline bool is_main_thread() const { return is_main_thread_; }
   inline ThreadId thread_id() const { return thread_id_; }
+  inline std::string node_version() const { return node_version_; }
 
   inline GcStatistics* gc_statistics() { return &gc_statistics_; }
   inline HttpStatistics* http_statistics() { return &http_statistics_; }
@@ -85,6 +86,7 @@ class EnvironmentData {
    * Use the JavaScript number representation.
    */
   ThreadId thread_id_ = ThreadId(-1);
+  std::string node_version_ = "";
 
   Mutex interrupt_mutex_;
   std::list<InterruptCallback> interrupt_requests_;

--- a/src/library/common.cc
+++ b/src/library/common.cc
@@ -3,6 +3,9 @@
 #include <atomic>
 #include <string>
 
+#include "environment_data.h"
+#include "v8.h"
+
 namespace xprofiler {
 namespace per_process {
 time_t load_time;
@@ -19,4 +22,9 @@ std::string GetStartTime(std::string format) {
 }
 
 size_t GetNextDiagFileId() { return per_process::next_file_id++; }
+
+std::string GetGlobalNodeVersion(v8::Isolate* isolate) {
+  EnvironmentData* env_data = EnvironmentData::GetCurrent(isolate);
+  return env_data->node_version();
+}
 }  // namespace xprofiler

--- a/src/library/common.h
+++ b/src/library/common.h
@@ -3,6 +3,8 @@
 
 #include <string>
 
+#include "v8.h"
+
 namespace xprofiler {
 constexpr uint64_t kNanosecondsPerSecond = 1e9;
 
@@ -12,6 +14,7 @@ void InitOnceLoadTime();
 unsigned long GetUptime();
 std::string GetStartTime(std::string format);
 size_t GetNextDiagFileId();
+std::string GetGlobalNodeVersion(v8::Isolate* isolate);
 
 /**
  * Update the type when we can get integer thread_id from Node.js

--- a/xprofiler.js
+++ b/xprofiler.js
@@ -17,6 +17,7 @@ const xprofiler = require(bindingPath);
 xprofiler.setup({
   isMainThread: workerThreads.isMainThread,
   threadId: workerThreads.threadId,
+  nodeVersion: process.version
 });
 
 const runOnceStatus = {


### PR DESCRIPTION
`diag_report` 中获取的 `nodeVersion` 需要是当前进程正在使用的 Node runtime，`NODE_VERSION` 宏定义则固定为预编译生成时使用的 Node runtime，这样会造成版本错误。

这里在初始化 Env 环境时带上 `process.version`，需要获取 Node runtime 版本处则通过 `env_data` 来进行获取。