### PR TITLE
fix: wrong incremental_marking_duration_last_record value

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -88,3 +88,30 @@ The externally maintained libraries used by xprofiler are:
     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   """
+
+- [Node.js](https://github.com/nodejs/node), located at:
+    - src/library/printf-inl.h
+    - src/library/printf.h
+    - src/library/writer.cc
+    - src/library/writer.h
+  is licensed as follows:
+  """
+    Copyright Node.js contributors. All rights reserved.
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to
+    deal in the Software without restriction, including without limitation the
+    rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+    sell copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+    IN THE SOFTWARE.
+  """

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,9 @@
 BSD 2-Clause License
 
-Copyright (c) 2019, hyj1991
-All rights reserved.
+xprofiler is licensed for use as follows:
+
+"""
+Copyright xprofiler contributors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
@@ -23,3 +25,66 @@ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+
+The xprofiler license applies to all parts of xprofiler that are not externally
+maintained libraries.
+
+The externally maintained libraries used by xprofiler are:
+
+- [nlohmann/json](https://github.com/nlohmann/json/blob/develop/LICENSE.MIT), located at src/library/json.hpp, is licensed as follows:
+  """
+    MIT License
+
+    Copyright (c) 2013-2022 Niels Lohmann
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+  """
+
+- [Percona-Lab/coredumper](https://github.com/Percona-Lab/coredumper), located at src/platform/unix/core/linux/, is licensed as follows:
+  """
+    Copyright (c) 2005-2007, Google Inc.
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+        * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+        * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following disclaimer
+    in the documentation and/or other materials provided with the
+    distribution.
+        * Neither the name of Google Inc. nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  """

--- a/binding.gyp
+++ b/binding.gyp
@@ -55,7 +55,7 @@
             "conditions": [
                 ["OS == 'linux'", {
                     "cflags": [
-                        "-O2",
+                        "-O3",
                         "-std=c++14",
                         "-Wno-sign-compare",
                         "-Wno-cast-function-type",
@@ -78,6 +78,7 @@
                 ["OS == 'mac'", {
                     "xcode_settings": {
                         "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
+                        "GCC_OPTIMIZATION_LEVEL": "3",
                         "OTHER_CFLAGS": [
                             "-std=c++14",
                             "-Wconversion",
@@ -101,7 +102,7 @@
                     "msvs_settings": {
                         "VCCLCompilerTool": {
                             "ExceptionHandling": "2",
-                            "Optimization": "2",
+                            "Optimization": "3",
                         },
                     },
                     "defines": [

--- a/src/library/printf-inl.h
+++ b/src/library/printf-inl.h
@@ -1,0 +1,116 @@
+#ifndef XPROFILER_SRC_LIBRARY_PRINT_INL_H
+#define XPROFILER_SRC_LIBRARY_PRINT_INL_H
+#include "printf.h"
+#include "util.h"
+
+namespace xprofiler {
+struct ToStringHelper {
+  template <typename T>
+  static std::string Convert(const T& value, std::string (T::*to_string)()
+                                                 const = &T::ToString) {
+    return (value.*to_string)();
+  }
+  template <typename T,
+            typename test_for_number = typename std::enable_if<
+                std::is_arithmetic<T>::value, bool>::type,
+            typename dummy = bool>
+  static std::string Convert(const T& value) {
+    return std::to_string(value);
+  }
+  static std::string Convert(const char* value) {
+    return value != nullptr ? value : "(null)";
+  }
+  static std::string Convert(const std::string& value) { return value; }
+  static std::string Convert(bool value) { return value ? "true" : "false"; }
+  template <unsigned BASE_BITS, typename T,
+            typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
+  static std::string BaseConvert(const T& value) {
+    auto v = static_cast<uint64_t>(value);
+    char ret[3 * sizeof(T)];
+    char* ptr = ret + 3 * sizeof(T) - 1;
+    *ptr = '\0';
+    const char* digits = "0123456789abcdef";
+    do {
+      unsigned digit = v & ((1 << BASE_BITS) - 1);
+      *--ptr = (BASE_BITS < 4 ? static_cast<char>('0' + digit) : digits[digit]);
+    } while ((v >>= BASE_BITS) != 0);
+    return ptr;
+  }
+  template <unsigned BASE_BITS, typename T,
+            typename std::enable_if<!std::is_integral<T>::value, int>::type = 0>
+  static std::string BaseConvert(T value) {
+    return Convert(std::forward<T>(value));
+  }
+};
+
+template <typename T>
+std::string ToString(const T& value) {
+  return ToStringHelper::Convert(value);
+}
+
+template <unsigned BASE_BITS, typename T>
+std::string ToBaseString(const T& value) {
+  return ToStringHelper::BaseConvert<BASE_BITS>(value);
+}
+
+inline std::string SPrintFImpl(const char* format) {
+  const char* p = strchr(format, '%');
+  if (LIKELY(p == nullptr)) return format;
+  CHECK_EQ(p[1], '%');  // Only '%%' allowed when there are no arguments.
+
+  return std::string(format, p + 1) + SPrintFImpl(p + 2);
+}
+
+template <typename Arg, typename... Args>
+std::string SPrintFImpl(  // NOLINT(runtime/string)
+    const char* format, Arg&& arg, Args&&... args) {
+  const char* p = strchr(format, '%');
+  if (p == nullptr) return "";
+  std::string ret(format, p);
+  // Ignore long / size_t modifiers
+  while (strchr("lz", *++p) != nullptr) {
+  }
+  switch (*p) {
+    case '%': {
+      return ret + '%' +
+             SPrintFImpl(p + 1, std::forward<Arg>(arg),
+                         std::forward<Args>(args)...);
+    }
+    default: {
+      return ret + '%' +
+             SPrintFImpl(p, std::forward<Arg>(arg),
+                         std::forward<Args>(args)...);
+    }
+    case 'f':
+    case 'd':
+    case 'i':
+    case 'u':
+    case 's':
+      ret += ToString(arg);
+      break;
+    case 'o':
+      ret += ToBaseString<3>(arg);
+      break;
+    case 'x':
+      ret += ToBaseString<4>(arg);
+      break;
+    case 'p': {
+      CHECK(std::is_pointer<typename std::remove_reference<Arg>::type>::value);
+      char out[20];
+      int n = snprintf(out, sizeof(out), "%p",
+                       *reinterpret_cast<const void* const*>(&arg));
+      CHECK_GE(n, 0);
+      ret += out;
+      break;
+    }
+  }
+  return ret + SPrintFImpl(p + 1, std::forward<Args>(args)...);
+}
+
+template <typename... Args>
+std::string SPrintF(  // NOLINT(runtime/string)
+    const char* format, Args&&... args) {
+  return SPrintFImpl(format, std::forward<Args>(args)...);
+}
+}  // namespace xprofiler
+#endif

--- a/src/library/printf.h
+++ b/src/library/printf.h
@@ -1,0 +1,9 @@
+#ifndef XPROFILER_SRC_LIBRARY_PRINT_H
+#define XPROFILER_SRC_LIBRARY_PRINT_H
+#include <string>
+
+namespace xprofiler {
+template <typename... Args>
+inline std::string SPrintF(const char* format, Args&&... args);
+}  // namespace xprofiler
+#endif

--- a/src/logbypass/cpu.cc
+++ b/src/logbypass/cpu.cc
@@ -22,7 +22,7 @@ namespace xprofiler {
 
 #define INIT_CPU_AVERAGE(period) double cpu_##period##_average = 0.0;
 
-#define ALINODE_LOG_KEY(period) "cpu_" #period ": %.2lf"
+#define ALINODE_LOG_KEY(period) "cpu_" #period ": %lf"
 
 #define XPROFILER_LOG_KEY(period) "cpu_" #period ": %lf"
 
@@ -76,7 +76,7 @@ void WriteCpuUsageInPeriod(bool log_format_alinode) {
     Info("other",
 #undef EXTRA_SYMBOL
 #define EXTRA_SYMBOL ", "
-         "cpu_usage(%%) now: %.2lf, " PERIOD_LIST(ALINODE_LOG_KEY),
+         "cpu_usage(%%) now: %lf, " PERIOD_LIST(ALINODE_LOG_KEY),
 #undef EXTRA_SYMBOL
 #define EXTRA_SYMBOL ,
          cpu_now, PERIOD_LIST(CPU_AVERAGE_VAL));

--- a/src/logbypass/http.cc
+++ b/src/logbypass/http.cc
@@ -95,7 +95,7 @@ void WriteHttpStatus(EnvironmentData* env_data, bool log_format_alinode,
          "live_http_request: %d, "
          "http_request_handled: %d, "
          "http_response_sent: %d, "
-         "http_rt: %.2lf",
+         "http_rt: %lf",
          http_statistics->live_http_request,
          http_statistics->http_response_sent,
          http_statistics->http_response_sent, rt);
@@ -116,7 +116,7 @@ void WriteHttpStatus(EnvironmentData* env_data, bool log_format_alinode,
           "http_response_sent: %d, "
           "http_request_timeout: %d, "
           "http_patch_timeout: %d, "
-          "http_rt: %.2lf",
+          "http_rt: %lf",
           format.c_str(), http_statistics->live_http_request,
           http_statistics->http_response_close,
           http_statistics->http_response_sent,

--- a/src/util.h
+++ b/src/util.h
@@ -78,6 +78,16 @@ struct AssertionInfo {
 #define DCHECK_IMPLIES(a, b)
 #endif
 
+#ifdef __GNUC__
+#define LIKELY(expr) __builtin_expect(!!(expr), 1)
+#define UNLIKELY(expr) __builtin_expect(!!(expr), 0)
+#define PRETTY_FUNCTION_NAME __PRETTY_FUNCTION__
+#else
+#define LIKELY(expr) expr
+#define UNLIKELY(expr) expr
+#define PRETTY_FUNCTION_NAME ""
+#endif
+
 #define UNREACHABLE(...) \
   ERROR_AND_ABORT("Unreachable code reached" __VA_OPT__(": ") __VA_ARGS__)
 

--- a/test/fixtures/logbypass.test.js
+++ b/test/fixtures/logbypass.test.js
@@ -48,7 +48,9 @@ setSpaceKeys(memoryKeys);
 const alindoeGcRule = /^\d+$/;
 const xprofilerGcRule = /^\d+$/;
 function getGcRules(list, alinode) {
-  return setRules(list, alinode, { alinodeRule: alindoeGcRule, xprofilerRule: xprofilerGcRule });
+  const alinodeRule = value => alindoeGcRule.test(value) && Number(value) < 1000;
+  const xprofilerRule = value => xprofilerGcRule.test(value) && Number(value) < 1000;
+  return setRules(list, alinode, { alinodeRule, xprofilerRule });
 }
 
 // libuv handles

--- a/test/logbypass.test.js
+++ b/test/logbypass.test.js
@@ -140,7 +140,12 @@ for (const testCase of cases) {
                 const key2 = utils.formatKey(key);
                 const regexp = key2 !== key ? struct[key2].regexp : struct[key2];
                 it(`${key}: ${detail[key]} shoule be ${regexp}`, function () {
-                  expect(regexp.test(detail[key])).to.be.ok();
+                  if (regexp instanceof RegExp) {
+                    expect(regexp.test(detail[key])).to.be.ok();
+                  }
+                  if (typeof regexp === 'function') {
+                    expect(regexp(detail[key])).to.be.ok();
+                  }
                 });
               }
             });


### PR DESCRIPTION
定义了宏 `__CHECK_WFORMAT__`  则 logbypass 数据记录前使用 `prinf` 进行校验：

```c++
#if defined(__CHECK_WFORMAT__)
#define RECORD(component, format, args...) \
  if (false) {                             \
    printf(format, args);                  \
  }                                        \
  Info(component, format, args);

#define RECORD_T(component, thread_id, format, args...) \
  if (false) {                                          \
    printf(format, args);                               \
  }                                                     \
  InfoT(component, thread_id, format, args);
#else
#define RECORD Info
#define RECORD_T InfoT
#endif
```

否则依旧使用原来的 `Info` 和 `InfoT` 进行处理，这样可以在 `npm run build` 对应的编译阶段提供 format 和对应 value 的精度校验，防止出现未定义行为，打包时则通过 `config.gypi` 去除 `__CHECK_WFORMAT__` 以完全使用原来的逻辑进行打包。

Reference：https://github.com/hyj1991/easy-monitor/issues/155