### PR TITLE
fix: fatalerror hook not working in node-v18.8.0

### DIFF
--- a/src/hooks/fatal_error.cc
+++ b/src/hooks/fatal_error.cc
@@ -17,6 +17,13 @@ using v8::Isolate;
 constexpr char module_type[] = "fatal_error";
 
 void DumpBeforeAbort(const char* location, const char* message) {
+  if (location) {
+    fprintf(stderr, "xprofiler: %s %s\n", location, message);
+  } else {
+    fprintf(stderr, "xprofiler: %s\n", message);
+  }
+  fflush(stderr);
+
   Isolate* isolate = TryGetCurrentIsolate();
   EnvironmentData* env_data = EnvironmentData::GetCurrent(isolate);
   ThreadId thread_id = env_data->thread_id();
@@ -41,13 +48,6 @@ void DumpBeforeAbort(const char* location, const char* message) {
     Coredumper::WriteCoredump(filepath);
     InfoT(module_type, thread_id, "core dumped.");
   }
-
-  if (location) {
-    fprintf(stderr, "xprofiler: %s %s\n", location, message);
-  } else {
-    fprintf(stderr, "xprofiler: %s\n", message);
-  }
-  fflush(stderr);
 }
 
 [[noreturn]] void OnOOMError(const char* location, bool is_heap_oom) {

--- a/src/hooks/fatal_error.cc
+++ b/src/hooks/fatal_error.cc
@@ -41,13 +41,6 @@ void DumpBeforeAbort(const char* location, const char* message) {
     Coredumper::WriteCoredump(filepath);
     InfoT(module_type, thread_id, "core dumped.");
   }
-}
-
-void OnOOMError(const char* location, bool is_heap_oom) {
-  const char* message =
-      is_heap_oom ? "Allocation failed - JavaScript heap out of memory"
-                  : "Allocation failed - process out of memory";
-  DumpBeforeAbort(location, message);
 
   if (location) {
     fprintf(stderr, "xprofiler: %s %s\n", location, message);
@@ -55,18 +48,18 @@ void OnOOMError(const char* location, bool is_heap_oom) {
     fprintf(stderr, "xprofiler: %s\n", message);
   }
   fflush(stderr);
+}
+
+[[noreturn]] void OnOOMError(const char* location, bool is_heap_oom) {
+  const char* message =
+      is_heap_oom ? "Allocation failed - JavaScript heap out of memory"
+                  : "Allocation failed - process out of memory";
+  DumpBeforeAbort(location, message);
   Abort();
 }
 
 [[noreturn]] void OnFatalError(const char* location, const char* message) {
   DumpBeforeAbort(location, message);
-
-  if (location) {
-    fprintf(stderr, "xprofiler: %s %s\n", location, message);
-  } else {
-    fprintf(stderr, "xprofiler: %s\n", message);
-  }
-  fflush(stderr);
   Abort();
 }
 

--- a/src/hooks/fatal_error.cc
+++ b/src/hooks/fatal_error.cc
@@ -16,14 +16,7 @@ using v8::Isolate;
 
 constexpr char module_type[] = "fatal_error";
 
-[[noreturn]] void OnFatalError(const char* location, const char* message) {
-  if (location) {
-    fprintf(stderr, "xprofiler: %s %s\n", location, message);
-  } else {
-    fprintf(stderr, "xprofiler: %s\n", message);
-  }
-  fflush(stderr);
-
+void DumpBeforeAbort(const char* location, const char* message) {
   Isolate* isolate = TryGetCurrentIsolate();
   EnvironmentData* env_data = EnvironmentData::GetCurrent(isolate);
   ThreadId thread_id = env_data->thread_id();
@@ -48,11 +41,37 @@ constexpr char module_type[] = "fatal_error";
     Coredumper::WriteCoredump(filepath);
     InfoT(module_type, thread_id, "core dumped.");
   }
+}
 
+void OnOOMError(const char* location, bool is_heap_oom) {
+  const char* message =
+      is_heap_oom ? "Allocation failed - JavaScript heap out of memory"
+                  : "Allocation failed - process out of memory";
+  DumpBeforeAbort(location, message);
+
+  if (location) {
+    fprintf(stderr, "xprofiler: %s %s\n", location, message);
+  } else {
+    fprintf(stderr, "xprofiler: %s\n", message);
+  }
+  fflush(stderr);
+  Abort();
+}
+
+[[noreturn]] void OnFatalError(const char* location, const char* message) {
+  DumpBeforeAbort(location, message);
+
+  if (location) {
+    fprintf(stderr, "xprofiler: %s %s\n", location, message);
+  } else {
+    fprintf(stderr, "xprofiler: %s\n", message);
+  }
+  fflush(stderr);
   Abort();
 }
 
 void SetFatalErrorHandler(v8::Isolate* isolate) {
+  isolate->SetOOMErrorHandler(OnOOMError);
   isolate->SetFatalErrorHandler(OnFatalError);
 }
 }  // namespace xprofiler

--- a/test/fixtures/logbypass.test.js
+++ b/test/fixtures/logbypass.test.js
@@ -48,8 +48,8 @@ setSpaceKeys(memoryKeys);
 const alindoeGcRule = /^\d+$/;
 const xprofilerGcRule = /^\d+$/;
 function getGcRules(list, alinode) {
-  const alinodeRule = value => alindoeGcRule.test(value) && Number(value) < 1000;
-  const xprofilerRule = value => xprofilerGcRule.test(value) && Number(value) < 1000;
+  const alinodeRule = value => alindoeGcRule.test(value) && Number(value) < 10000;
+  const xprofilerRule = value => xprofilerGcRule.test(value) && Number(value) < 10000;
   return setRules(list, alinode, { alinodeRule, xprofilerRule });
 }
 


### PR DESCRIPTION
`node-v18.8.0` 中的新版 report 实现拦截了 `oom` 事件，使得原本 xprofiler 中的 fatal error hook 无法生效，这里通过增加 oom hook 来避免被 runtime 里面的逻辑覆盖掉

值得注意的是，`enable_fatal_error_coredump` 和 `enable_fatal_error_hook` 配置为 `false` 则不会覆盖 runtime 里面的拦截处理。


Reference: 
* https://github.com/nodejs/node/pull/44242/files#diff-5f2fc380364ef43210af4a28c08f9a0c7ec5f85e3ec1f5c1df5e0204eb9dc721R243
* https://github.com/nodejs/node/pull/44242/files#diff-16cddcd719418092bf9f602309598657f14d1160548cb2803ab98a16328a4f3dR558