### PR TITLE
fix: output native stack if HAVE_EXECINFO_H defined

### DIFF
--- a/src/platform/unix/report.cc
+++ b/src/platform/unix/report.cc
@@ -4,9 +4,19 @@
 #define __STDC_FORMAT_MACROS
 #endif
 
+#if defined(__linux__) && !defined(__GLIBC__) || defined(__UCLIBC__) || \
+    defined(_AIX)
+#define HAVE_EXECINFO_H 0
+#else
+#define HAVE_EXECINFO_H 1
+#endif
+
+#if HAVE_EXECINFO_H
 #include <cxxabi.h>
-#include <dlfcn.h>
 #include <execinfo.h>
+#endif
+
+#include <dlfcn.h>
 #include <inttypes.h>
 #include <sys/resource.h>
 #include <sys/utsname.h>
@@ -47,12 +57,7 @@ string GetPcAddress(void* pc) {
   return (string)buf;
 }
 
-#if (defined(__linux__) && !defined(__GLIBC__))
-void PrintNativeStack(JSONWriter* writer) {
-  writer->json_arraystart("nativeStacks");
-  writer->json_arrayend();
-}
-#else
+#if (HAVE_EXECINFO_H)
 void PrintNativeStack(JSONWriter* writer) {
   writer->json_arraystart("nativeStacks");
   void* frames[256];
@@ -79,6 +84,11 @@ void PrintNativeStack(JSONWriter* writer) {
     }
     writer->json_end();
   }
+  writer->json_arrayend();
+}
+#else
+void PrintNativeStack(JSONWriter* writer) {
+  writer->json_arraystart("nativeStacks");
   writer->json_arrayend();
 }
 #endif


### PR DESCRIPTION
## 背景

`alpine` 等环境下缺少 `execinfo` 库函数导致 `--build-from-source` 失败。


## 优化

本 PR 增加 `HAVE_EXECINFO_H` 宏：

```c++
#if defined(__linux__) && !defined(__GLIBC__) || defined(__UCLIBC__) || \
    defined(_AIX)
#define HAVE_EXECINFO_H 0
#else
#define HAVE_EXECINFO_H 1
#endif
```

且仅在 `HAVE_EXECINFO_H` 生效时诊断报告输出 Native stack，否则输出空：

```c++
#if HAVE_EXECINFO_H
#include <cxxabi.h>
#include <execinfo.h>
#endif

#if (HAVE_EXECINFO_H)
void PrintNativeStack(JSONWriter* writer) {
  // 此时获取 native stack 详细信息
}
#else
void PrintNativeStack(JSONWriter* writer) {
  writer->json_arraystart("nativeStacks");
  writer->json_arrayend();
}
#endif
```

## 验证

已在 `alpine@3.16` 上验证通过。


## 其它

Reference：
* https://github.com/nodejs/node/blob/main/src/debug_utils.cc#L15-L21

