### PR TITLE
Release 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xprofiler",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "node.js addon to output runtime logs",
   "bin": {
     "xprofctl": "bin/xprofctl"

--- a/scripts/versions.js
+++ b/scripts/versions.js
@@ -3,12 +3,12 @@
 exports.os7u = [
   'node-v12.22.12',
   'node-v13.14.0',
-  'node-v14.19.3',
+  'node-v14.20.1',
   'node-v15.14.0',
-  'node-v16.15.1',
+  'node-v16.17.1',
   'node-v17.9.1',
 ];
 
 exports.os8u = [
-  'node-v18.4.0',
+  'node-v18.10.0',
 ];


### PR DESCRIPTION
Commits:

* [1538d8c] fix: output native trace if HAVE_EXECINFO_H defined (#196)
* [5c594a0] fix: remove upload (#194)
* [b4feaf4] chore: update deps (#193)
* [29d8b72] fix: fatalerror hook not working in node-v18.8.0 (#192)
* [92f651c] fix: fix nested gc callback (#188)