### PR TITLE
optimize: take action

### DIFF
--- a/src/commands/dump.h
+++ b/src/commands/dump.h
@@ -22,7 +22,6 @@ enum DumpAction {
 };
 
 using ActionMap = std::unordered_map<int, bool>;
-using RequestMap = std::unordered_map<std::string, bool>;
 using ConflictMap = std::unordered_map<int, std::vector<DumpAction>>;
 using DependentMap = std::unordered_map<int, DumpAction>;
 


### PR DESCRIPTION
## 背景

早期 1.x 版本在尚未实现 `worker_threads` 监控时，开发者的采样操作会通过 `requestInterrupt` & `uv_async_send` 同时通知js 主线程 —— 这意味着 `HandleAction` 在早期实现中会执行两次。

因此旧版实现中在 `HandleAction` 执行前校验了 `TransactionDone` 这个函数，通过 `${uuid}::${action}` 的唯一 key 设置状态判断当前的 action 是否已经由 `requestInterrupt` or `uv_async_send` 执行过了，如果已经执行过，则清理 data 然后返回。

而在最新的实现中，将 `HandleAction` 放置到一个 lambda 回调中：

```c++
static void NotifyJsThread(EnvironmentData* env_data, void* data) {
  env_data->RequestInterrupt(
      [data](EnvironmentData* env_data, InterruptKind kind) {
        HandleAction(env_data->isolate(), data,
                     kind == InterruptKind::kBusy ? "v8_request_interrupt" : "uv_async_send");
      });
}
```

并且这个回调函数会放入每一个 EnvData 对应的 `std:list` 中，这样 `requestInterrupt` & `uv_async_send` 先触发的那一个会通过 `std::list::swap` 执行回调，后触发拿到的 `std::list` 为空不会再触发。

这样 `HandleAction` 只会执行一次，旧版本中设计的 `TransactionDone` 逻辑不再需要。

## 优化

移除当前实现中为 `HandleAction` 执行两次所做的冗余设计逻辑