### PR TITLE
fix: ignore clean error

### DIFF
--- a/lib/clean.js
+++ b/lib/clean.js
@@ -33,7 +33,7 @@ module.exports = function clean(logdir) {
     try {
       fs.unlinkSync(path.join(logdir, filename));
     } catch (err) /* istanbul ignore next */ {
-      console.error(err);
+      // console.error(err);
     }
   });
 };


### PR DESCRIPTION
cluster 模式下并发启动 Node 进程可能会重复清理无效的旧 domain socket 文件，这里的错误可以忽略，无需打印出来造成干扰

清理旧 sock 失败不应该影响主流程。