### PR TITLE
refactor: replace dump actions static storages with EnvironmentData

### DIFF
--- a/src/environment_data.h
+++ b/src/environment_data.h
@@ -70,7 +70,7 @@ class EnvironmentData {
   inline uv_thread_t* uv_profiling_callback_thread() {
     return &uv_profiling_callback_thread_;
   };
-  ActionMap action_map;
+  inline ActionMap* action_map() { return &action_map_; }
   std::string cpuprofile_filepath = "";
   std::string sampling_heapprofile_filepath = "";
   std::string heapsnapshot_filepath = "";
@@ -115,6 +115,8 @@ class EnvironmentData {
 
   uint32_t closed_handle_count_ = 0;
   static const uint32_t kHandleCount = 2;
+
+  ActionMap action_map_;
 };
 
 }  // namespace xprofiler

--- a/src/environment_data.h
+++ b/src/environment_data.h
@@ -5,6 +5,7 @@
 #include <list>
 
 #include "commands/cpuprofiler/cpu_profiler.h"
+#include "commands/dump.h"
 #include "commands/gcprofiler/gc_profiler.h"
 #include "library/common.h"
 #include "logbypass/gc.h"
@@ -65,6 +66,18 @@ class EnvironmentData {
   std::unique_ptr<GcProfiler> gc_profiler;
   std::unique_ptr<CpuProfiler> cpu_profiler;
 
+  // dump action
+  inline uv_thread_t* uv_profiling_callback_thread() {
+    return &uv_profiling_callback_thread_;
+  };
+  ActionMap action_map;
+  std::string cpuprofile_filepath = "";
+  std::string sampling_heapprofile_filepath = "";
+  std::string heapsnapshot_filepath = "";
+  std::string gcprofile_filepath = "";
+  std::string node_report_filepath = "";
+  std::string coredump_filepath = "";
+
  private:
   static void AtExit(void* arg);
   template <uv_async_t EnvironmentData::*field>
@@ -80,6 +93,7 @@ class EnvironmentData {
   v8::Isolate* isolate_;
   uv_loop_t* loop_;
   uv_async_t statistics_async_;
+  uv_thread_t uv_profiling_callback_thread_;
 
   bool is_main_thread_ = false;
   /* We don't have a native method to get the uint64_t thread id.


### PR DESCRIPTION
## 背景
目前的 `dump.cc` 中实现的采样动作，依赖全局变量处理，存在两个问题：

* 对于 `worker_thread` / `main js thread` 间并发调用各种 action 不友好
* 需要进行退出前未完结采样动作立即结束并输出文件时由于 dtor 的问题会使得变量信息丢失

此 PR 将 actions 中涉及到的变量放置到 `EnvironmentData` 实例中存储，解决上述问题。

## 测试

局部逻辑重构，依靠现有 `command.test.js` 保证功能没有 break。

Reference: https://github.com/X-Profiler/xprofiler/pull/202